### PR TITLE
Add support to from_api for non-wikipedia wikis

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -54,7 +54,7 @@ its a combination of [instaview](https://en.wikipedia.org/wiki/User:Pilaf/InstaV
 
 #Methods
 * **.parse(markup)** - turns wikipedia markup into a nice json object
-* **.from_api(title, callback)** -  retrieves raw contents of a wikipedia article
+* **.from_api(title, lang_or_wikiid, callback)** -  retrieves raw contents of a wikipedia article - or other mediawiki wiki identified by its dbname in http://en.wikipedia.org/w/api.php?action=sitematrix&format=json
 * **.plaintext(markup)** -  returns only nice text of the article
 
 if you're scripting this from the shell, install -g, and:

--- a/fetch_sitematrix.js
+++ b/fetch_sitematrix.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+/**
+ * Simple script to update sitematrix.json
+ */
+
+"use strict";
+
+require('es6-shim');
+require('prfun');
+
+var fs = require("fs"),
+  writeFile = Promise.promisify(fs.writeFile, false, fs),
+  request = Promise.promisify(require('request'), true),
+  downloadUrl = "https://en.wikipedia.org/w/api.php?action=sitematrix&format=json",
+  filename = "sitematrix.js";
+
+request({
+  url: downloadUrl,
+  json: true
+}).spread(function(res, body) {
+  if ( res.statusCode !== 200 ) {
+    throw "Error fetching sitematrix! Returned " + res.statusCode;
+  }
+  return writeFile(
+    filename,
+    "var sitematrix = " + JSON.stringify(body, null, "\t") + ";\n" +
+    "module.exports = sitematrix;"
+  );
+}).then(function() {
+  console.log("Success!");
+}).done();

--- a/fetch_text.js
+++ b/fetch_text.js
@@ -1,13 +1,36 @@
 var request=require("request")
 
-var fetch=function(page, lang, cb){
-  var lang= lang || 'en'
-  var url='http://'+lang+'.wikipedia.org/w/index.php?action=raw&title='+page
+var SITE_MATRIX_URL = "https://en.wikipedia.org/w/api.php?action=sitematrix&format=json";
+var site_map = {};
+
+function init_site_map() {
+  if (Object.keys(site_map).length !== 0) {
+    return;
+  }
+  var sitematrix_raw=require("./sitematrix");
+  var sitematrix = sitematrix_raw.sitematrix;
+  Object.keys(sitematrix).forEach(function(key){
+    sitematrix[key].site.forEach(function(site){
+      site_map[site.dbname] = site.url;
+    });
+  });
+}
+
+var fetch=function(page, lang_or_wikiid, cb){
+  lang_or_wikiid = lang_or_wikiid || 'en';
+  var url;
+  if (lang_or_wikiid.length !== 2) {
+    init_site_map();
+    console.log(Object.keys(site_map), lang_or_wikiid);
+    url=site_map[lang_or_wikiid]+'/w/index.php?action=raw&title='+page;
+  } else {
+    url='http://'+lang_or_wikiid+'.wikipedia.org/w/index.php?action=raw&title='+page;
+  }
   request({
     uri: url,
   }, function(error, response, body) {
     if(error){
-      console.log(error)
+      console.log(error);
     }
     cb(body);
   });

--- a/fetch_text.js
+++ b/fetch_text.js
@@ -21,7 +21,6 @@ var fetch=function(page, lang_or_wikiid, cb){
   var url;
   if (lang_or_wikiid.length !== 2) {
     init_site_map();
-    console.log(Object.keys(site_map), lang_or_wikiid);
     url=site_map[lang_or_wikiid]+'/w/index.php?action=raw&title='+page;
   } else {
     url='http://'+lang_or_wikiid+'.wikipedia.org/w/index.php?action=raw&title='+page;

--- a/index.js
+++ b/index.js
@@ -520,17 +520,17 @@ var wtf_wikipedia=(function(){
 
     }
 
-    var from_api=function(page, lang, cb){
-      if(typeof lang=="function"){
-        cb= lang
-        lang="en"
+    var from_api=function(page, lang_or_wikiid, cb){
+      if(typeof lang_or_wikiid=="function"){
+        cb= lang_or_wikiid
+        lang_or_wikiid="en"
       }
       cb= cb || console.log
-      lang=lang||"en"
+      lang_or_wikiid=lang_or_wikiid||"en"
       if(!fetch){//no http method, on the client side
         return cb(null)
       }
-      fetch(page, lang, cb)
+      fetch(page, lang_or_wikiid, cb)
     }
 
     var plaintext=function(str){

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   },
   "devDependencies": {
     "grunt-contrib-uglify": "*",
-    "grunt-contrib-concat": "*"
+    "grunt-contrib-concat": "*",
+    "prfun": "*",
+    "es6-shim": "*"
   },
   "scripts": {
     "test": "node tests/test.js",

--- a/sitematrix.js
+++ b/sitematrix.js
@@ -1,0 +1,7429 @@
+var sitematrix = {
+	"sitematrix": {
+		"0": {
+			"code": "aa",
+			"name": "Qafár af",
+			"site": [
+				{
+					"url": "http://aa.wikipedia.org",
+					"dbname": "aawiki",
+					"code": "wiki",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://aa.wiktionary.org",
+					"dbname": "aawiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://aa.wikibooks.org",
+					"dbname": "aawikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Afar"
+		},
+		"1": {
+			"code": "ab",
+			"name": "Аҧсшәа",
+			"site": [
+				{
+					"url": "http://ab.wikipedia.org",
+					"dbname": "abwiki",
+					"code": "wiki",
+					"sitename": "Авикипедиа"
+				},
+				{
+					"url": "http://ab.wiktionary.org",
+					"dbname": "abwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Abkhazian"
+		},
+		"2": {
+			"code": "ace",
+			"name": "Acèh",
+			"site": [
+				{
+					"url": "http://ace.wikipedia.org",
+					"dbname": "acewiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Achinese"
+		},
+		"3": {
+			"code": "af",
+			"name": "Afrikaans",
+			"site": [
+				{
+					"url": "http://af.wikipedia.org",
+					"dbname": "afwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://af.wiktionary.org",
+					"dbname": "afwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://af.wikibooks.org",
+					"dbname": "afwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://af.wikiquote.org",
+					"dbname": "afwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Afrikaans"
+		},
+		"4": {
+			"code": "ak",
+			"name": "Akan",
+			"site": [
+				{
+					"url": "http://ak.wikipedia.org",
+					"dbname": "akwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ak.wiktionary.org",
+					"dbname": "akwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://ak.wikibooks.org",
+					"dbname": "akwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Akan"
+		},
+		"5": {
+			"code": "als",
+			"name": "Alemannisch",
+			"site": [
+				{
+					"url": "http://als.wikipedia.org",
+					"dbname": "alswiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://als.wiktionary.org",
+					"dbname": "alswiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://als.wikibooks.org",
+					"dbname": "alswikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://als.wikiquote.org",
+					"dbname": "alswikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Alemannisch"
+		},
+		"6": {
+			"code": "am",
+			"name": "አማርኛ",
+			"site": [
+				{
+					"url": "http://am.wikipedia.org",
+					"dbname": "amwiki",
+					"code": "wiki",
+					"sitename": "ውክፔዲያ"
+				},
+				{
+					"url": "http://am.wiktionary.org",
+					"dbname": "amwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://am.wikiquote.org",
+					"dbname": "amwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Amharic"
+		},
+		"7": {
+			"code": "an",
+			"name": "aragonés",
+			"site": [
+				{
+					"url": "http://an.wikipedia.org",
+					"dbname": "anwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://an.wiktionary.org",
+					"dbname": "anwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Aragonese"
+		},
+		"8": {
+			"code": "ang",
+			"name": "Ænglisc",
+			"site": [
+				{
+					"url": "http://ang.wikipedia.org",
+					"dbname": "angwiki",
+					"code": "wiki",
+					"sitename": "Wikipǣdia"
+				},
+				{
+					"url": "http://ang.wiktionary.org",
+					"dbname": "angwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikiwordbōc"
+				},
+				{
+					"url": "http://ang.wikibooks.org",
+					"dbname": "angwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://ang.wikiquote.org",
+					"dbname": "angwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://ang.wikisource.org",
+					"dbname": "angwikisource",
+					"code": "wikisource",
+					"sitename": "Wicifruma",
+					"closed": ""
+				}
+			],
+			"localname": "Old English"
+		},
+		"9": {
+			"code": "ar",
+			"name": "العربية",
+			"site": [
+				{
+					"url": "http://ar.wikipedia.org",
+					"dbname": "arwiki",
+					"code": "wiki",
+					"sitename": "ويكيبيديا"
+				},
+				{
+					"url": "http://ar.wiktionary.org",
+					"dbname": "arwiktionary",
+					"code": "wiktionary",
+					"sitename": "ويكاموس"
+				},
+				{
+					"url": "http://ar.wikibooks.org",
+					"dbname": "arwikibooks",
+					"code": "wikibooks",
+					"sitename": "ويكي_الكتب"
+				},
+				{
+					"url": "http://ar.wikinews.org",
+					"dbname": "arwikinews",
+					"code": "wikinews",
+					"sitename": "ويكي_الأخبار"
+				},
+				{
+					"url": "http://ar.wikiquote.org",
+					"dbname": "arwikiquote",
+					"code": "wikiquote",
+					"sitename": "ويكي_الاقتباس"
+				},
+				{
+					"url": "http://ar.wikisource.org",
+					"dbname": "arwikisource",
+					"code": "wikisource",
+					"sitename": "ويكي_مصدر"
+				},
+				{
+					"url": "http://ar.wikiversity.org",
+					"dbname": "arwikiversity",
+					"code": "wikiversity",
+					"sitename": "ويكي الجامعة"
+				}
+			],
+			"localname": "Arabic"
+		},
+		"10": {
+			"code": "arc",
+			"name": "ܐܪܡܝܐ",
+			"site": [
+				{
+					"url": "http://arc.wikipedia.org",
+					"dbname": "arcwiki",
+					"code": "wiki",
+					"sitename": "ܘܝܩܝܦܕܝܐ"
+				}
+			],
+			"localname": "Aramaic"
+		},
+		"11": {
+			"code": "arz",
+			"name": "مصرى",
+			"site": [
+				{
+					"url": "http://arz.wikipedia.org",
+					"dbname": "arzwiki",
+					"code": "wiki",
+					"sitename": "ويكيبيديا"
+				}
+			],
+			"localname": "Egyptian Spoken Arabic"
+		},
+		"12": {
+			"code": "as",
+			"name": "অসমীয়া",
+			"site": [
+				{
+					"url": "http://as.wikipedia.org",
+					"dbname": "aswiki",
+					"code": "wiki",
+					"sitename": "অসমীয়া ৱিকিপিডিয়া"
+				},
+				{
+					"url": "http://as.wiktionary.org",
+					"dbname": "aswiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://as.wikibooks.org",
+					"dbname": "aswikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://as.wikisource.org",
+					"dbname": "aswikisource",
+					"code": "wikisource",
+					"sitename": "ৱিকিউৎস"
+				}
+			],
+			"localname": "Assamese"
+		},
+		"13": {
+			"code": "ast",
+			"name": "asturianu",
+			"site": [
+				{
+					"url": "http://ast.wikipedia.org",
+					"dbname": "astwiki",
+					"code": "wiki",
+					"sitename": "Uiquipedia"
+				},
+				{
+					"url": "http://ast.wiktionary.org",
+					"dbname": "astwiktionary",
+					"code": "wiktionary",
+					"sitename": "Uiccionariu"
+				},
+				{
+					"url": "http://ast.wikibooks.org",
+					"dbname": "astwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://ast.wikiquote.org",
+					"dbname": "astwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Asturian"
+		},
+		"14": {
+			"code": "av",
+			"name": "авар",
+			"site": [
+				{
+					"url": "http://av.wikipedia.org",
+					"dbname": "avwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://av.wiktionary.org",
+					"dbname": "avwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Avaric"
+		},
+		"15": {
+			"code": "ay",
+			"name": "Aymar aru",
+			"site": [
+				{
+					"url": "http://ay.wikipedia.org",
+					"dbname": "aywiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ay.wiktionary.org",
+					"dbname": "aywiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ay.wikibooks.org",
+					"dbname": "aywikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Aymara"
+		},
+		"16": {
+			"code": "az",
+			"name": "azərbaycanca",
+			"site": [
+				{
+					"url": "http://az.wikipedia.org",
+					"dbname": "azwiki",
+					"code": "wiki",
+					"sitename": "Vikipediya"
+				},
+				{
+					"url": "http://az.wiktionary.org",
+					"dbname": "azwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://az.wikibooks.org",
+					"dbname": "azwikibooks",
+					"code": "wikibooks",
+					"sitename": "Vikikitab"
+				},
+				{
+					"url": "http://az.wikiquote.org",
+					"dbname": "azwikiquote",
+					"code": "wikiquote",
+					"sitename": "Vikisitat"
+				},
+				{
+					"url": "http://az.wikisource.org",
+					"dbname": "azwikisource",
+					"code": "wikisource",
+					"sitename": "VikiMənbə"
+				}
+			],
+			"localname": "Azerbaijani"
+		},
+		"17": {
+			"code": "ba",
+			"name": "башҡортса",
+			"site": [
+				{
+					"url": "http://ba.wikipedia.org",
+					"dbname": "bawiki",
+					"code": "wiki",
+					"sitename": "Википедия"
+				},
+				{
+					"url": "http://ba.wikibooks.org",
+					"dbname": "bawikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Bashkir"
+		},
+		"18": {
+			"code": "bar",
+			"name": "Boarisch",
+			"site": [
+				{
+					"url": "http://bar.wikipedia.org",
+					"dbname": "barwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Bavarian"
+		},
+		"19": {
+			"code": "bat-smg",
+			"name": "žemaitėška",
+			"site": [
+				{
+					"url": "http://bat-smg.wikipedia.org",
+					"dbname": "bat_smgwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Samogitian"
+		},
+		"20": {
+			"code": "bcl",
+			"name": "Bikol Central",
+			"site": [
+				{
+					"url": "http://bcl.wikipedia.org",
+					"dbname": "bclwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Bikol Central"
+		},
+		"21": {
+			"code": "be",
+			"name": "беларуская",
+			"site": [
+				{
+					"url": "http://be.wikipedia.org",
+					"dbname": "bewiki",
+					"code": "wiki",
+					"sitename": "Вікіпедыя"
+				},
+				{
+					"url": "http://be.wiktionary.org",
+					"dbname": "bewiktionary",
+					"code": "wiktionary",
+					"sitename": "Вікіслоўнік"
+				},
+				{
+					"url": "http://be.wikibooks.org",
+					"dbname": "bewikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://be.wikiquote.org",
+					"dbname": "bewikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://be.wikisource.org",
+					"dbname": "bewikisource",
+					"code": "wikisource",
+					"sitename": "Вікікрыніцы"
+				}
+			],
+			"localname": "Belarusian"
+		},
+		"22": {
+			"code": "be-x-old",
+			"name": "беларуская (тарашкевіца)‎",
+			"site": [
+				{
+					"url": "http://be-x-old.wikipedia.org",
+					"dbname": "be_x_oldwiki",
+					"code": "wiki",
+					"sitename": "Вікіпэдыя"
+				}
+			],
+			"localname": "беларуская (тарашкевіца)‎"
+		},
+		"23": {
+			"code": "bg",
+			"name": "български",
+			"site": [
+				{
+					"url": "http://bg.wikipedia.org",
+					"dbname": "bgwiki",
+					"code": "wiki",
+					"sitename": "Уикипедия"
+				},
+				{
+					"url": "http://bg.wiktionary.org",
+					"dbname": "bgwiktionary",
+					"code": "wiktionary",
+					"sitename": "Уикиречник"
+				},
+				{
+					"url": "http://bg.wikibooks.org",
+					"dbname": "bgwikibooks",
+					"code": "wikibooks",
+					"sitename": "Уикикниги"
+				},
+				{
+					"url": "http://bg.wikinews.org",
+					"dbname": "bgwikinews",
+					"code": "wikinews",
+					"sitename": "Уикиновини"
+				},
+				{
+					"url": "http://bg.wikiquote.org",
+					"dbname": "bgwikiquote",
+					"code": "wikiquote",
+					"sitename": "Уикицитат"
+				},
+				{
+					"url": "http://bg.wikisource.org",
+					"dbname": "bgwikisource",
+					"code": "wikisource",
+					"sitename": "Уикиизточник"
+				}
+			],
+			"localname": "Bulgarian"
+		},
+		"24": {
+			"code": "bh",
+			"name": "भोजपुरी",
+			"site": [
+				{
+					"url": "http://bh.wikipedia.org",
+					"dbname": "bhwiki",
+					"code": "wiki",
+					"sitename": "विकिपीडिया"
+				},
+				{
+					"url": "http://bh.wiktionary.org",
+					"dbname": "bhwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "भोजपुरी"
+		},
+		"25": {
+			"code": "bi",
+			"name": "Bislama",
+			"site": [
+				{
+					"url": "http://bi.wikipedia.org",
+					"dbname": "biwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://bi.wiktionary.org",
+					"dbname": "biwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://bi.wikibooks.org",
+					"dbname": "biwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Bislama"
+		},
+		"26": {
+			"code": "bjn",
+			"name": "Bahasa Banjar",
+			"site": [
+				{
+					"url": "http://bjn.wikipedia.org",
+					"dbname": "bjnwiki",
+					"code": "wiki",
+					"sitename": "Wikipidia"
+				}
+			],
+			"localname": "Banjar"
+		},
+		"27": {
+			"code": "bm",
+			"name": "bamanankan",
+			"site": [
+				{
+					"url": "http://bm.wikipedia.org",
+					"dbname": "bmwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://bm.wiktionary.org",
+					"dbname": "bmwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://bm.wikibooks.org",
+					"dbname": "bmwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://bm.wikiquote.org",
+					"dbname": "bmwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Bambara"
+		},
+		"28": {
+			"code": "bn",
+			"name": "বাংলা",
+			"site": [
+				{
+					"url": "http://bn.wikipedia.org",
+					"dbname": "bnwiki",
+					"code": "wiki",
+					"sitename": "উইকিপিডিয়া"
+				},
+				{
+					"url": "http://bn.wiktionary.org",
+					"dbname": "bnwiktionary",
+					"code": "wiktionary",
+					"sitename": "উইকিঅভিধান"
+				},
+				{
+					"url": "http://bn.wikibooks.org",
+					"dbname": "bnwikibooks",
+					"code": "wikibooks",
+					"sitename": "উইকিবই"
+				},
+				{
+					"url": "http://bn.wikisource.org",
+					"dbname": "bnwikisource",
+					"code": "wikisource",
+					"sitename": "উইকিসংকলন"
+				}
+			],
+			"localname": "Bengali"
+		},
+		"29": {
+			"code": "bo",
+			"name": "བོད་ཡིག",
+			"site": [
+				{
+					"url": "http://bo.wikipedia.org",
+					"dbname": "bowiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://bo.wiktionary.org",
+					"dbname": "bowiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://bo.wikibooks.org",
+					"dbname": "bowikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Tibetan"
+		},
+		"30": {
+			"code": "bpy",
+			"name": "বিষ্ণুপ্রিয়া মণিপুরী",
+			"site": [
+				{
+					"url": "http://bpy.wikipedia.org",
+					"dbname": "bpywiki",
+					"code": "wiki",
+					"sitename": "উইকিপিডিয়া"
+				}
+			],
+			"localname": "Bishnupuriya Manipuri"
+		},
+		"31": {
+			"code": "br",
+			"name": "brezhoneg",
+			"site": [
+				{
+					"url": "http://br.wikipedia.org",
+					"dbname": "brwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://br.wiktionary.org",
+					"dbname": "brwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikeriadur"
+				},
+				{
+					"url": "http://br.wikiquote.org",
+					"dbname": "brwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikiarroud"
+				},
+				{
+					"url": "http://br.wikisource.org",
+					"dbname": "brwikisource",
+					"code": "wikisource",
+					"sitename": "Wikimammenn"
+				}
+			],
+			"localname": "Breton"
+		},
+		"32": {
+			"code": "bs",
+			"name": "bosanski",
+			"site": [
+				{
+					"url": "http://bs.wikipedia.org",
+					"dbname": "bswiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://bs.wiktionary.org",
+					"dbname": "bswiktionary",
+					"code": "wiktionary",
+					"sitename": "Vikirječnik"
+				},
+				{
+					"url": "http://bs.wikibooks.org",
+					"dbname": "bswikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikiknjige"
+				},
+				{
+					"url": "http://bs.wikinews.org",
+					"dbname": "bswikinews",
+					"code": "wikinews",
+					"sitename": "Wikivijesti"
+				},
+				{
+					"url": "http://bs.wikiquote.org",
+					"dbname": "bswikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikicitati"
+				},
+				{
+					"url": "http://bs.wikisource.org",
+					"dbname": "bswikisource",
+					"code": "wikisource",
+					"sitename": "Wikizvor"
+				}
+			],
+			"localname": "Bosnian"
+		},
+		"33": {
+			"code": "bug",
+			"name": "ᨅᨔ ᨕᨘᨁᨗ",
+			"site": [
+				{
+					"url": "http://bug.wikipedia.org",
+					"dbname": "bugwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Buginese"
+		},
+		"34": {
+			"code": "bxr",
+			"name": "буряад",
+			"site": [
+				{
+					"url": "http://bxr.wikipedia.org",
+					"dbname": "bxrwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "буряад"
+		},
+		"35": {
+			"code": "ca",
+			"name": "català",
+			"site": [
+				{
+					"url": "http://ca.wikipedia.org",
+					"dbname": "cawiki",
+					"code": "wiki",
+					"sitename": "Viquipèdia"
+				},
+				{
+					"url": "http://ca.wiktionary.org",
+					"dbname": "cawiktionary",
+					"code": "wiktionary",
+					"sitename": "Viccionari"
+				},
+				{
+					"url": "http://ca.wikibooks.org",
+					"dbname": "cawikibooks",
+					"code": "wikibooks",
+					"sitename": "Viquillibres"
+				},
+				{
+					"url": "http://ca.wikinews.org",
+					"dbname": "cawikinews",
+					"code": "wikinews",
+					"sitename": "Viquinotícies"
+				},
+				{
+					"url": "http://ca.wikiquote.org",
+					"dbname": "cawikiquote",
+					"code": "wikiquote",
+					"sitename": "Viquidites"
+				},
+				{
+					"url": "http://ca.wikisource.org",
+					"dbname": "cawikisource",
+					"code": "wikisource",
+					"sitename": "Viquitexts"
+				}
+			],
+			"localname": "Catalan"
+		},
+		"36": {
+			"code": "cbk-zam",
+			"name": "Chavacano de Zamboanga",
+			"site": [
+				{
+					"url": "http://cbk-zam.wikipedia.org",
+					"dbname": "cbk_zamwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Chavacano de Zamboanga"
+		},
+		"37": {
+			"code": "cdo",
+			"name": "Mìng-dĕ̤ng-ngṳ̄",
+			"site": [
+				{
+					"url": "http://cdo.wikipedia.org",
+					"dbname": "cdowiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Min Dong Chinese"
+		},
+		"38": {
+			"code": "ce",
+			"name": "нохчийн",
+			"site": [
+				{
+					"url": "http://ce.wikipedia.org",
+					"dbname": "cewiki",
+					"code": "wiki",
+					"sitename": "Википеди"
+				}
+			],
+			"localname": "Chechen"
+		},
+		"39": {
+			"code": "ceb",
+			"name": "Cebuano",
+			"site": [
+				{
+					"url": "http://ceb.wikipedia.org",
+					"dbname": "cebwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Cebuano"
+		},
+		"40": {
+			"code": "ch",
+			"name": "Chamoru",
+			"site": [
+				{
+					"url": "http://ch.wikipedia.org",
+					"dbname": "chwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ch.wiktionary.org",
+					"dbname": "chwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://ch.wikibooks.org",
+					"dbname": "chwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Chamorro"
+		},
+		"41": {
+			"code": "cho",
+			"name": "Choctaw",
+			"site": [
+				{
+					"url": "http://cho.wikipedia.org",
+					"dbname": "chowiki",
+					"code": "wiki",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Choctaw"
+		},
+		"42": {
+			"code": "chr",
+			"name": "ᏣᎳᎩ",
+			"site": [
+				{
+					"url": "http://chr.wikipedia.org",
+					"dbname": "chrwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://chr.wiktionary.org",
+					"dbname": "chrwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Cherokee"
+		},
+		"43": {
+			"code": "chy",
+			"name": "Tsetsêhestâhese",
+			"site": [
+				{
+					"url": "http://chy.wikipedia.org",
+					"dbname": "chywiki",
+					"code": "wiki",
+					"sitename": "Tsétsêhéstâhese Wikipedia"
+				}
+			],
+			"localname": "Cheyenne"
+		},
+		"44": {
+			"code": "ckb",
+			"name": "کوردی",
+			"site": [
+				{
+					"url": "http://ckb.wikipedia.org",
+					"dbname": "ckbwiki",
+					"code": "wiki",
+					"sitename": "ویکیپیدیا"
+				}
+			],
+			"localname": "Sorani Kurdish"
+		},
+		"45": {
+			"code": "co",
+			"name": "corsu",
+			"site": [
+				{
+					"url": "http://co.wikipedia.org",
+					"dbname": "cowiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://co.wiktionary.org",
+					"dbname": "cowiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://co.wikibooks.org",
+					"dbname": "cowikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://co.wikiquote.org",
+					"dbname": "cowikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Corsican"
+		},
+		"46": {
+			"code": "cr",
+			"name": "Nēhiyawēwin / ᓀᐦᐃᔭᐍᐏᐣ",
+			"site": [
+				{
+					"url": "http://cr.wikipedia.org",
+					"dbname": "crwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://cr.wiktionary.org",
+					"dbname": "crwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://cr.wikiquote.org",
+					"dbname": "crwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Cree"
+		},
+		"47": {
+			"code": "crh",
+			"name": "qırımtatarca",
+			"site": [
+				{
+					"url": "http://crh.wikipedia.org",
+					"dbname": "crhwiki",
+					"code": "wiki",
+					"sitename": "Vikipediya"
+				}
+			],
+			"localname": "Crimean Turkish"
+		},
+		"48": {
+			"code": "cs",
+			"name": "čeština",
+			"site": [
+				{
+					"url": "http://cs.wikipedia.org",
+					"dbname": "cswiki",
+					"code": "wiki",
+					"sitename": "Wikipedie"
+				},
+				{
+					"url": "http://cs.wiktionary.org",
+					"dbname": "cswiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikislovník"
+				},
+				{
+					"url": "http://cs.wikibooks.org",
+					"dbname": "cswikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikiknihy"
+				},
+				{
+					"url": "http://cs.wikinews.org",
+					"dbname": "cswikinews",
+					"code": "wikinews",
+					"sitename": "Wikizprávy"
+				},
+				{
+					"url": "http://cs.wikiquote.org",
+					"dbname": "cswikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikicitáty"
+				},
+				{
+					"url": "http://cs.wikisource.org",
+					"dbname": "cswikisource",
+					"code": "wikisource",
+					"sitename": "Wikizdroje"
+				},
+				{
+					"url": "http://cs.wikiversity.org",
+					"dbname": "cswikiversity",
+					"code": "wikiversity",
+					"sitename": "Wikiverzita"
+				}
+			],
+			"localname": "Czech"
+		},
+		"49": {
+			"code": "csb",
+			"name": "kaszëbsczi",
+			"site": [
+				{
+					"url": "http://csb.wikipedia.org",
+					"dbname": "csbwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://csb.wiktionary.org",
+					"dbname": "csbwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Kashubian"
+		},
+		"50": {
+			"code": "cu",
+			"name": "словѣньскъ / ⰔⰎⰑⰂⰡⰐⰠⰔⰍⰟ",
+			"site": [
+				{
+					"url": "http://cu.wikipedia.org",
+					"dbname": "cuwiki",
+					"code": "wiki",
+					"sitename": "Википєдїꙗ"
+				}
+			],
+			"localname": "Church Slavic"
+		},
+		"51": {
+			"code": "cv",
+			"name": "Чӑвашла",
+			"site": [
+				{
+					"url": "http://cv.wikipedia.org",
+					"dbname": "cvwiki",
+					"code": "wiki",
+					"sitename": "Википеди"
+				},
+				{
+					"url": "http://cv.wikibooks.org",
+					"dbname": "cvwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Chuvash"
+		},
+		"52": {
+			"code": "cy",
+			"name": "Cymraeg",
+			"site": [
+				{
+					"url": "http://cy.wikipedia.org",
+					"dbname": "cywiki",
+					"code": "wiki",
+					"sitename": "Wicipedia"
+				},
+				{
+					"url": "http://cy.wiktionary.org",
+					"dbname": "cywiktionary",
+					"code": "wiktionary",
+					"sitename": "Wiciadur"
+				},
+				{
+					"url": "http://cy.wikibooks.org",
+					"dbname": "cywikibooks",
+					"code": "wikibooks",
+					"sitename": "Wicilyfrau"
+				},
+				{
+					"url": "http://cy.wikiquote.org",
+					"dbname": "cywikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://cy.wikisource.org",
+					"dbname": "cywikisource",
+					"code": "wikisource",
+					"sitename": "Wicidestun"
+				}
+			],
+			"localname": "Welsh"
+		},
+		"53": {
+			"code": "da",
+			"name": "dansk",
+			"site": [
+				{
+					"url": "http://da.wikipedia.org",
+					"dbname": "dawiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://da.wiktionary.org",
+					"dbname": "dawiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://da.wikibooks.org",
+					"dbname": "dawikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://da.wikiquote.org",
+					"dbname": "dawikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://da.wikisource.org",
+					"dbname": "dawikisource",
+					"code": "wikisource",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Danish"
+		},
+		"54": {
+			"code": "de",
+			"name": "Deutsch",
+			"site": [
+				{
+					"url": "http://de.wikipedia.org",
+					"dbname": "dewiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://de.wiktionary.org",
+					"dbname": "dewiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://de.wikibooks.org",
+					"dbname": "dewikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://de.wikinews.org",
+					"dbname": "dewikinews",
+					"code": "wikinews",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://de.wikiquote.org",
+					"dbname": "dewikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://de.wikisource.org",
+					"dbname": "dewikisource",
+					"code": "wikisource",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://de.wikiversity.org",
+					"dbname": "dewikiversity",
+					"code": "wikiversity",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://de.wikivoyage.org",
+					"dbname": "dewikivoyage",
+					"code": "wikivoyage",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "German"
+		},
+		"55": {
+			"code": "diq",
+			"name": "Zazaki",
+			"site": [
+				{
+					"url": "http://diq.wikipedia.org",
+					"dbname": "diqwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Zazaki"
+		},
+		"56": {
+			"code": "dsb",
+			"name": "dolnoserbski",
+			"site": [
+				{
+					"url": "http://dsb.wikipedia.org",
+					"dbname": "dsbwiki",
+					"code": "wiki",
+					"sitename": "Wikipedija"
+				}
+			],
+			"localname": "Lower Sorbian"
+		},
+		"57": {
+			"code": "dv",
+			"name": "ދިވެހިބަސް",
+			"site": [
+				{
+					"url": "http://dv.wikipedia.org",
+					"dbname": "dvwiki",
+					"code": "wiki",
+					"sitename": "ވިކިޕީޑިއާ"
+				},
+				{
+					"url": "http://dv.wiktionary.org",
+					"dbname": "dvwiktionary",
+					"code": "wiktionary",
+					"sitename": "ވިކިރަދީފު"
+				}
+			],
+			"localname": "Divehi"
+		},
+		"58": {
+			"code": "dz",
+			"name": "ཇོང་ཁ",
+			"site": [
+				{
+					"url": "http://dz.wikipedia.org",
+					"dbname": "dzwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://dz.wiktionary.org",
+					"dbname": "dzwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Dzongkha"
+		},
+		"59": {
+			"code": "ee",
+			"name": "eʋegbe",
+			"site": [
+				{
+					"url": "http://ee.wikipedia.org",
+					"dbname": "eewiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Ewe"
+		},
+		"60": {
+			"code": "el",
+			"name": "Ελληνικά",
+			"site": [
+				{
+					"url": "http://el.wikipedia.org",
+					"dbname": "elwiki",
+					"code": "wiki",
+					"sitename": "Βικιπαίδεια"
+				},
+				{
+					"url": "http://el.wiktionary.org",
+					"dbname": "elwiktionary",
+					"code": "wiktionary",
+					"sitename": "Βικιλεξικό"
+				},
+				{
+					"url": "http://el.wikibooks.org",
+					"dbname": "elwikibooks",
+					"code": "wikibooks",
+					"sitename": "Βικιβιβλία"
+				},
+				{
+					"url": "http://el.wikinews.org",
+					"dbname": "elwikinews",
+					"code": "wikinews",
+					"sitename": "Βικινέα"
+				},
+				{
+					"url": "http://el.wikiquote.org",
+					"dbname": "elwikiquote",
+					"code": "wikiquote",
+					"sitename": "Βικιφθέγματα"
+				},
+				{
+					"url": "http://el.wikisource.org",
+					"dbname": "elwikisource",
+					"code": "wikisource",
+					"sitename": "Βικιθήκη"
+				},
+				{
+					"url": "http://el.wikiversity.org",
+					"dbname": "elwikiversity",
+					"code": "wikiversity",
+					"sitename": "Βικιεπιστήμιο"
+				},
+				{
+					"url": "http://el.wikivoyage.org",
+					"dbname": "elwikivoyage",
+					"code": "wikivoyage",
+					"sitename": "Βικιταξίδια"
+				}
+			],
+			"localname": "Greek"
+		},
+		"61": {
+			"code": "eml",
+			"name": "emiliàn e rumagnòl",
+			"site": [
+				{
+					"url": "http://eml.wikipedia.org",
+					"dbname": "emlwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Emiliano-Romagnolo"
+		},
+		"62": {
+			"code": "en",
+			"name": "English",
+			"site": [
+				{
+					"url": "http://en.wikipedia.org",
+					"dbname": "enwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://en.wiktionary.org",
+					"dbname": "enwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://en.wikibooks.org",
+					"dbname": "enwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://en.wikinews.org",
+					"dbname": "enwikinews",
+					"code": "wikinews",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://en.wikiquote.org",
+					"dbname": "enwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://en.wikisource.org",
+					"dbname": "enwikisource",
+					"code": "wikisource",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://en.wikiversity.org",
+					"dbname": "enwikiversity",
+					"code": "wikiversity",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://en.wikivoyage.org",
+					"dbname": "enwikivoyage",
+					"code": "wikivoyage",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "English"
+		},
+		"63": {
+			"code": "eo",
+			"name": "Esperanto",
+			"site": [
+				{
+					"url": "http://eo.wikipedia.org",
+					"dbname": "eowiki",
+					"code": "wiki",
+					"sitename": "Vikipedio"
+				},
+				{
+					"url": "http://eo.wiktionary.org",
+					"dbname": "eowiktionary",
+					"code": "wiktionary",
+					"sitename": "Vikivortaro"
+				},
+				{
+					"url": "http://eo.wikibooks.org",
+					"dbname": "eowikibooks",
+					"code": "wikibooks",
+					"sitename": "Vikilibroj"
+				},
+				{
+					"url": "http://eo.wikinews.org",
+					"dbname": "eowikinews",
+					"code": "wikinews",
+					"sitename": "Vikinovaĵoj"
+				},
+				{
+					"url": "http://eo.wikiquote.org",
+					"dbname": "eowikiquote",
+					"code": "wikiquote",
+					"sitename": "Vikicitaro"
+				},
+				{
+					"url": "http://eo.wikisource.org",
+					"dbname": "eowikisource",
+					"code": "wikisource",
+					"sitename": "Vikifontaro"
+				}
+			],
+			"localname": "Esperanto"
+		},
+		"64": {
+			"code": "es",
+			"name": "español",
+			"site": [
+				{
+					"url": "http://es.wikipedia.org",
+					"dbname": "eswiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://es.wiktionary.org",
+					"dbname": "eswiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikcionario"
+				},
+				{
+					"url": "http://es.wikibooks.org",
+					"dbname": "eswikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikilibros"
+				},
+				{
+					"url": "http://es.wikinews.org",
+					"dbname": "eswikinews",
+					"code": "wikinews",
+					"sitename": "Wikinoticias"
+				},
+				{
+					"url": "http://es.wikiquote.org",
+					"dbname": "eswikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://es.wikisource.org",
+					"dbname": "eswikisource",
+					"code": "wikisource",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://es.wikiversity.org",
+					"dbname": "eswikiversity",
+					"code": "wikiversity",
+					"sitename": "Wikiversidad"
+				},
+				{
+					"url": "http://es.wikivoyage.org",
+					"dbname": "eswikivoyage",
+					"code": "wikivoyage",
+					"sitename": "Wikiviajes"
+				}
+			],
+			"localname": "Spanish"
+		},
+		"65": {
+			"code": "et",
+			"name": "eesti",
+			"site": [
+				{
+					"url": "http://et.wikipedia.org",
+					"dbname": "etwiki",
+					"code": "wiki",
+					"sitename": "Vikipeedia"
+				},
+				{
+					"url": "http://et.wiktionary.org",
+					"dbname": "etwiktionary",
+					"code": "wiktionary",
+					"sitename": "Vikisõnastik"
+				},
+				{
+					"url": "http://et.wikibooks.org",
+					"dbname": "etwikibooks",
+					"code": "wikibooks",
+					"sitename": "Vikiõpikud"
+				},
+				{
+					"url": "http://et.wikiquote.org",
+					"dbname": "etwikiquote",
+					"code": "wikiquote",
+					"sitename": "Vikitsitaadid"
+				},
+				{
+					"url": "http://et.wikisource.org",
+					"dbname": "etwikisource",
+					"code": "wikisource",
+					"sitename": "Vikitekstid"
+				}
+			],
+			"localname": "Estonian"
+		},
+		"66": {
+			"code": "eu",
+			"name": "euskara",
+			"site": [
+				{
+					"url": "http://eu.wikipedia.org",
+					"dbname": "euwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://eu.wiktionary.org",
+					"dbname": "euwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://eu.wikibooks.org",
+					"dbname": "euwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://eu.wikiquote.org",
+					"dbname": "euwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Basque"
+		},
+		"67": {
+			"code": "ext",
+			"name": "estremeñu",
+			"site": [
+				{
+					"url": "http://ext.wikipedia.org",
+					"dbname": "extwiki",
+					"code": "wiki",
+					"sitename": "Güiquipeya"
+				}
+			],
+			"localname": "Extremaduran"
+		},
+		"68": {
+			"code": "fa",
+			"name": "فارسی",
+			"site": [
+				{
+					"url": "http://fa.wikipedia.org",
+					"dbname": "fawiki",
+					"code": "wiki",
+					"sitename": "ویکی‌پدیا"
+				},
+				{
+					"url": "http://fa.wiktionary.org",
+					"dbname": "fawiktionary",
+					"code": "wiktionary",
+					"sitename": "ویکی‌واژه"
+				},
+				{
+					"url": "http://fa.wikibooks.org",
+					"dbname": "fawikibooks",
+					"code": "wikibooks",
+					"sitename": "ویکی‌کتاب"
+				},
+				{
+					"url": "http://fa.wikinews.org",
+					"dbname": "fawikinews",
+					"code": "wikinews",
+					"sitename": "ویکی‌خبر"
+				},
+				{
+					"url": "http://fa.wikiquote.org",
+					"dbname": "fawikiquote",
+					"code": "wikiquote",
+					"sitename": "ویکی‌گفتاورد"
+				},
+				{
+					"url": "http://fa.wikisource.org",
+					"dbname": "fawikisource",
+					"code": "wikisource",
+					"sitename": "ویکی‌نبشته"
+				},
+				{
+					"url": "http://fa.wikivoyage.org",
+					"dbname": "fawikivoyage",
+					"code": "wikivoyage",
+					"sitename": "ویکی‌سفر"
+				}
+			],
+			"localname": "Persian"
+		},
+		"69": {
+			"code": "ff",
+			"name": "Fulfulde",
+			"site": [
+				{
+					"url": "http://ff.wikipedia.org",
+					"dbname": "ffwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Fulah"
+		},
+		"70": {
+			"code": "fi",
+			"name": "suomi",
+			"site": [
+				{
+					"url": "http://fi.wikipedia.org",
+					"dbname": "fiwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://fi.wiktionary.org",
+					"dbname": "fiwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikisanakirja"
+				},
+				{
+					"url": "http://fi.wikibooks.org",
+					"dbname": "fiwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikikirjasto"
+				},
+				{
+					"url": "http://fi.wikinews.org",
+					"dbname": "fiwikinews",
+					"code": "wikinews",
+					"sitename": "Wikiuutiset"
+				},
+				{
+					"url": "http://fi.wikiquote.org",
+					"dbname": "fiwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikisitaatit"
+				},
+				{
+					"url": "http://fi.wikisource.org",
+					"dbname": "fiwikisource",
+					"code": "wikisource",
+					"sitename": "Wikiaineisto"
+				},
+				{
+					"url": "http://fi.wikiversity.org",
+					"dbname": "fiwikiversity",
+					"code": "wikiversity",
+					"sitename": "Wikiopisto"
+				}
+			],
+			"localname": "Finnish"
+		},
+		"71": {
+			"code": "fiu-vro",
+			"name": "Võro",
+			"site": [
+				{
+					"url": "http://fiu-vro.wikipedia.org",
+					"dbname": "fiu_vrowiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Võro"
+		},
+		"72": {
+			"code": "fj",
+			"name": "Na Vosa Vakaviti",
+			"site": [
+				{
+					"url": "http://fj.wikipedia.org",
+					"dbname": "fjwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://fj.wiktionary.org",
+					"dbname": "fjwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Fijian"
+		},
+		"73": {
+			"code": "fo",
+			"name": "føroyskt",
+			"site": [
+				{
+					"url": "http://fo.wikipedia.org",
+					"dbname": "fowiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://fo.wiktionary.org",
+					"dbname": "fowiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://fo.wikisource.org",
+					"dbname": "fowikisource",
+					"code": "wikisource",
+					"sitename": "Wikiheimild"
+				}
+			],
+			"localname": "Faroese"
+		},
+		"74": {
+			"code": "fr",
+			"name": "français",
+			"site": [
+				{
+					"url": "http://fr.wikipedia.org",
+					"dbname": "frwiki",
+					"code": "wiki",
+					"sitename": "Wikipédia"
+				},
+				{
+					"url": "http://fr.wiktionary.org",
+					"dbname": "frwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wiktionnaire"
+				},
+				{
+					"url": "http://fr.wikibooks.org",
+					"dbname": "frwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikilivres"
+				},
+				{
+					"url": "http://fr.wikinews.org",
+					"dbname": "frwikinews",
+					"code": "wikinews",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://fr.wikiquote.org",
+					"dbname": "frwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://fr.wikisource.org",
+					"dbname": "frwikisource",
+					"code": "wikisource",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://fr.wikiversity.org",
+					"dbname": "frwikiversity",
+					"code": "wikiversity",
+					"sitename": "Wikiversité"
+				},
+				{
+					"url": "http://fr.wikivoyage.org",
+					"dbname": "frwikivoyage",
+					"code": "wikivoyage",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "French"
+		},
+		"75": {
+			"code": "frp",
+			"name": "arpetan",
+			"site": [
+				{
+					"url": "http://frp.wikipedia.org",
+					"dbname": "frpwiki",
+					"code": "wiki",
+					"sitename": "Vouiquipèdia"
+				}
+			],
+			"localname": "Franco-Provençal"
+		},
+		"76": {
+			"code": "frr",
+			"name": "Nordfriisk",
+			"site": [
+				{
+					"url": "http://frr.wikipedia.org",
+					"dbname": "frrwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Northern Frisian"
+		},
+		"77": {
+			"code": "fur",
+			"name": "furlan",
+			"site": [
+				{
+					"url": "http://fur.wikipedia.org",
+					"dbname": "furwiki",
+					"code": "wiki",
+					"sitename": "Vichipedie"
+				}
+			],
+			"localname": "Friulian"
+		},
+		"78": {
+			"code": "fy",
+			"name": "Frysk",
+			"site": [
+				{
+					"url": "http://fy.wikipedia.org",
+					"dbname": "fywiki",
+					"code": "wiki",
+					"sitename": "Wikipedy"
+				},
+				{
+					"url": "http://fy.wiktionary.org",
+					"dbname": "fywiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://fy.wikibooks.org",
+					"dbname": "fywikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Western Frisian"
+		},
+		"79": {
+			"code": "ga",
+			"name": "Gaeilge",
+			"site": [
+				{
+					"url": "http://ga.wikipedia.org",
+					"dbname": "gawiki",
+					"code": "wiki",
+					"sitename": "Vicipéid"
+				},
+				{
+					"url": "http://ga.wiktionary.org",
+					"dbname": "gawiktionary",
+					"code": "wiktionary",
+					"sitename": "Vicífhoclóir"
+				},
+				{
+					"url": "http://ga.wikibooks.org",
+					"dbname": "gawikibooks",
+					"code": "wikibooks",
+					"sitename": "Vicíleabhair",
+					"closed": ""
+				},
+				{
+					"url": "http://ga.wikiquote.org",
+					"dbname": "gawikiquote",
+					"code": "wikiquote",
+					"sitename": "Vicísliocht",
+					"closed": ""
+				}
+			],
+			"localname": "Irish"
+		},
+		"80": {
+			"code": "gag",
+			"name": "Gagauz",
+			"site": [
+				{
+					"url": "http://gag.wikipedia.org",
+					"dbname": "gagwiki",
+					"code": "wiki",
+					"sitename": "Vikipediya"
+				}
+			],
+			"localname": "Gagauz"
+		},
+		"81": {
+			"code": "gan",
+			"name": "贛語",
+			"site": [
+				{
+					"url": "http://gan.wikipedia.org",
+					"dbname": "ganwiki",
+					"code": "wiki",
+					"sitename": "維基百科"
+				}
+			],
+			"localname": "Gan"
+		},
+		"82": {
+			"code": "gd",
+			"name": "Gàidhlig",
+			"site": [
+				{
+					"url": "http://gd.wikipedia.org",
+					"dbname": "gdwiki",
+					"code": "wiki",
+					"sitename": "Uicipeid"
+				},
+				{
+					"url": "http://gd.wiktionary.org",
+					"dbname": "gdwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Scottish Gaelic"
+		},
+		"83": {
+			"code": "gl",
+			"name": "galego",
+			"site": [
+				{
+					"url": "http://gl.wikipedia.org",
+					"dbname": "glwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://gl.wiktionary.org",
+					"dbname": "glwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://gl.wikibooks.org",
+					"dbname": "glwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://gl.wikiquote.org",
+					"dbname": "glwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://gl.wikisource.org",
+					"dbname": "glwikisource",
+					"code": "wikisource",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Galician"
+		},
+		"84": {
+			"code": "glk",
+			"name": "گیلکی",
+			"site": [
+				{
+					"url": "http://glk.wikipedia.org",
+					"dbname": "glkwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Gilaki"
+		},
+		"85": {
+			"code": "gn",
+			"name": "Avañe'ẽ",
+			"site": [
+				{
+					"url": "http://gn.wikipedia.org",
+					"dbname": "gnwiki",
+					"code": "wiki",
+					"sitename": "Vikipetã"
+				},
+				{
+					"url": "http://gn.wiktionary.org",
+					"dbname": "gnwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://gn.wikibooks.org",
+					"dbname": "gnwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Guarani"
+		},
+		"86": {
+			"code": "got",
+			"name": "𐌲𐌿𐍄𐌹𐍃𐌺",
+			"site": [
+				{
+					"url": "http://got.wikipedia.org",
+					"dbname": "gotwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://got.wikibooks.org",
+					"dbname": "gotwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Gothic"
+		},
+		"87": {
+			"code": "gu",
+			"name": "ગુજરાતી",
+			"site": [
+				{
+					"url": "http://gu.wikipedia.org",
+					"dbname": "guwiki",
+					"code": "wiki",
+					"sitename": "વિકિપીડિયા"
+				},
+				{
+					"url": "http://gu.wiktionary.org",
+					"dbname": "guwiktionary",
+					"code": "wiktionary",
+					"sitename": "વિક્શનરી"
+				},
+				{
+					"url": "http://gu.wikibooks.org",
+					"dbname": "guwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://gu.wikiquote.org",
+					"dbname": "guwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://gu.wikisource.org",
+					"dbname": "guwikisource",
+					"code": "wikisource",
+					"sitename": "વિકિસ્રોત"
+				}
+			],
+			"localname": "Gujarati"
+		},
+		"88": {
+			"code": "gv",
+			"name": "Gaelg",
+			"site": [
+				{
+					"url": "http://gv.wikipedia.org",
+					"dbname": "gvwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://gv.wiktionary.org",
+					"dbname": "gvwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Manx"
+		},
+		"89": {
+			"code": "ha",
+			"name": "Hausa",
+			"site": [
+				{
+					"url": "http://ha.wikipedia.org",
+					"dbname": "hawiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ha.wiktionary.org",
+					"dbname": "hawiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Hausa"
+		},
+		"90": {
+			"code": "hak",
+			"name": "客家語/Hak-kâ-ngî",
+			"site": [
+				{
+					"url": "http://hak.wikipedia.org",
+					"dbname": "hakwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Hakka"
+		},
+		"91": {
+			"code": "haw",
+			"name": "Hawai`i",
+			"site": [
+				{
+					"url": "http://haw.wikipedia.org",
+					"dbname": "hawwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Hawaiian"
+		},
+		"92": {
+			"code": "he",
+			"name": "עברית",
+			"site": [
+				{
+					"url": "http://he.wikipedia.org",
+					"dbname": "hewiki",
+					"code": "wiki",
+					"sitename": "ויקיפדיה"
+				},
+				{
+					"url": "http://he.wiktionary.org",
+					"dbname": "hewiktionary",
+					"code": "wiktionary",
+					"sitename": "ויקימילון"
+				},
+				{
+					"url": "http://he.wikibooks.org",
+					"dbname": "hewikibooks",
+					"code": "wikibooks",
+					"sitename": "ויקיספר"
+				},
+				{
+					"url": "http://he.wikinews.org",
+					"dbname": "hewikinews",
+					"code": "wikinews",
+					"sitename": "ויקיחדשות"
+				},
+				{
+					"url": "http://he.wikiquote.org",
+					"dbname": "hewikiquote",
+					"code": "wikiquote",
+					"sitename": "ויקיציטוט"
+				},
+				{
+					"url": "http://he.wikisource.org",
+					"dbname": "hewikisource",
+					"code": "wikisource",
+					"sitename": "ויקיטקסט"
+				},
+				{
+					"url": "http://he.wikivoyage.org",
+					"dbname": "hewikivoyage",
+					"code": "wikivoyage",
+					"sitename": "ויקימסע"
+				}
+			],
+			"localname": "Hebrew"
+		},
+		"93": {
+			"code": "hi",
+			"name": "हिन्दी",
+			"site": [
+				{
+					"url": "http://hi.wikipedia.org",
+					"dbname": "hiwiki",
+					"code": "wiki",
+					"sitename": "विकिपीडिया"
+				},
+				{
+					"url": "http://hi.wiktionary.org",
+					"dbname": "hiwiktionary",
+					"code": "wiktionary",
+					"sitename": "विक्षनरी"
+				},
+				{
+					"url": "http://hi.wikibooks.org",
+					"dbname": "hiwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://hi.wikiquote.org",
+					"dbname": "hiwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Hindi"
+		},
+		"94": {
+			"code": "hif",
+			"name": "Fiji Hindi",
+			"site": [
+				{
+					"url": "http://hif.wikipedia.org",
+					"dbname": "hifwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Fiji Hindi"
+		},
+		"95": {
+			"code": "ho",
+			"name": "Hiri Motu",
+			"site": [
+				{
+					"url": "http://ho.wikipedia.org",
+					"dbname": "howiki",
+					"code": "wiki",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Hiri Motu"
+		},
+		"96": {
+			"code": "hr",
+			"name": "hrvatski",
+			"site": [
+				{
+					"url": "http://hr.wikipedia.org",
+					"dbname": "hrwiki",
+					"code": "wiki",
+					"sitename": "Wikipedija"
+				},
+				{
+					"url": "http://hr.wiktionary.org",
+					"dbname": "hrwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://hr.wikibooks.org",
+					"dbname": "hrwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://hr.wikiquote.org",
+					"dbname": "hrwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikicitat"
+				},
+				{
+					"url": "http://hr.wikisource.org",
+					"dbname": "hrwikisource",
+					"code": "wikisource",
+					"sitename": "Wikizvor"
+				}
+			],
+			"localname": "Croatian"
+		},
+		"97": {
+			"code": "hsb",
+			"name": "hornjoserbsce",
+			"site": [
+				{
+					"url": "http://hsb.wikipedia.org",
+					"dbname": "hsbwiki",
+					"code": "wiki",
+					"sitename": "Wikipedija"
+				},
+				{
+					"url": "http://hsb.wiktionary.org",
+					"dbname": "hsbwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikisłownik"
+				}
+			],
+			"localname": "Upper Sorbian"
+		},
+		"98": {
+			"code": "ht",
+			"name": "Kreyòl ayisyen",
+			"site": [
+				{
+					"url": "http://ht.wikipedia.org",
+					"dbname": "htwiki",
+					"code": "wiki",
+					"sitename": "Wikipedya"
+				},
+				{
+					"url": "http://ht.wikisource.org",
+					"dbname": "htwikisource",
+					"code": "wikisource",
+					"sitename": "Wikisòrs",
+					"closed": ""
+				}
+			],
+			"localname": "Haitian"
+		},
+		"99": {
+			"code": "hu",
+			"name": "magyar",
+			"site": [
+				{
+					"url": "http://hu.wikipedia.org",
+					"dbname": "huwiki",
+					"code": "wiki",
+					"sitename": "Wikipédia"
+				},
+				{
+					"url": "http://hu.wiktionary.org",
+					"dbname": "huwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikiszótár"
+				},
+				{
+					"url": "http://hu.wikibooks.org",
+					"dbname": "huwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikikönyvek"
+				},
+				{
+					"url": "http://hu.wikinews.org",
+					"dbname": "huwikinews",
+					"code": "wikinews",
+					"sitename": "Wikihírek",
+					"closed": ""
+				},
+				{
+					"url": "http://hu.wikiquote.org",
+					"dbname": "huwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikidézet"
+				},
+				{
+					"url": "http://hu.wikisource.org",
+					"dbname": "huwikisource",
+					"code": "wikisource",
+					"sitename": "Wikiforrás"
+				}
+			],
+			"localname": "Hungarian"
+		},
+		"100": {
+			"code": "hy",
+			"name": "Հայերեն",
+			"site": [
+				{
+					"url": "http://hy.wikipedia.org",
+					"dbname": "hywiki",
+					"code": "wiki",
+					"sitename": "Վիքիպեդիա"
+				},
+				{
+					"url": "http://hy.wiktionary.org",
+					"dbname": "hywiktionary",
+					"code": "wiktionary",
+					"sitename": "Վիքիբառարան"
+				},
+				{
+					"url": "http://hy.wikibooks.org",
+					"dbname": "hywikibooks",
+					"code": "wikibooks",
+					"sitename": "Վիքիգրքեր"
+				},
+				{
+					"url": "http://hy.wikiquote.org",
+					"dbname": "hywikiquote",
+					"code": "wikiquote",
+					"sitename": "Վիքիքաղվածք"
+				},
+				{
+					"url": "http://hy.wikisource.org",
+					"dbname": "hywikisource",
+					"code": "wikisource",
+					"sitename": "Վիքիդարան"
+				}
+			],
+			"localname": "Armenian"
+		},
+		"101": {
+			"code": "hz",
+			"name": "Otsiherero",
+			"site": [
+				{
+					"url": "http://hz.wikipedia.org",
+					"dbname": "hzwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Herero"
+		},
+		"102": {
+			"code": "ia",
+			"name": "interlingua",
+			"site": [
+				{
+					"url": "http://ia.wikipedia.org",
+					"dbname": "iawiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ia.wiktionary.org",
+					"dbname": "iawiktionary",
+					"code": "wiktionary",
+					"sitename": "Wiktionario"
+				},
+				{
+					"url": "http://ia.wikibooks.org",
+					"dbname": "iawikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Interlingua"
+		},
+		"103": {
+			"code": "id",
+			"name": "Bahasa Indonesia",
+			"site": [
+				{
+					"url": "http://id.wikipedia.org",
+					"dbname": "idwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://id.wiktionary.org",
+					"dbname": "idwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://id.wikibooks.org",
+					"dbname": "idwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikibuku"
+				},
+				{
+					"url": "http://id.wikiquote.org",
+					"dbname": "idwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://id.wikisource.org",
+					"dbname": "idwikisource",
+					"code": "wikisource",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Indonesian"
+		},
+		"104": {
+			"code": "ie",
+			"name": "Interlingue",
+			"site": [
+				{
+					"url": "http://ie.wikipedia.org",
+					"dbname": "iewiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ie.wiktionary.org",
+					"dbname": "iewiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ie.wikibooks.org",
+					"dbname": "iewikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Interlingue"
+		},
+		"105": {
+			"code": "ig",
+			"name": "Igbo",
+			"site": [
+				{
+					"url": "http://ig.wikipedia.org",
+					"dbname": "igwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Igbo"
+		},
+		"106": {
+			"code": "ii",
+			"name": "ꆇꉙ",
+			"site": [
+				{
+					"url": "http://ii.wikipedia.org",
+					"dbname": "iiwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Sichuan Yi"
+		},
+		"107": {
+			"code": "ik",
+			"name": "Iñupiak",
+			"site": [
+				{
+					"url": "http://ik.wikipedia.org",
+					"dbname": "ikwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ik.wiktionary.org",
+					"dbname": "ikwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Inupiaq"
+		},
+		"108": {
+			"code": "ilo",
+			"name": "Ilokano",
+			"site": [
+				{
+					"url": "http://ilo.wikipedia.org",
+					"dbname": "ilowiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Iloko"
+		},
+		"109": {
+			"code": "io",
+			"name": "Ido",
+			"site": [
+				{
+					"url": "http://io.wikipedia.org",
+					"dbname": "iowiki",
+					"code": "wiki",
+					"sitename": "Wikipedio"
+				},
+				{
+					"url": "http://io.wiktionary.org",
+					"dbname": "iowiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikivortaro"
+				}
+			],
+			"localname": "Ido"
+		},
+		"110": {
+			"code": "is",
+			"name": "íslenska",
+			"site": [
+				{
+					"url": "http://is.wikipedia.org",
+					"dbname": "iswiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://is.wiktionary.org",
+					"dbname": "iswiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikiorðabók"
+				},
+				{
+					"url": "http://is.wikibooks.org",
+					"dbname": "iswikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikibækur"
+				},
+				{
+					"url": "http://is.wikiquote.org",
+					"dbname": "iswikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikivitnun"
+				},
+				{
+					"url": "http://is.wikisource.org",
+					"dbname": "iswikisource",
+					"code": "wikisource",
+					"sitename": "Wikiheimild"
+				}
+			],
+			"localname": "Icelandic"
+		},
+		"111": {
+			"code": "it",
+			"name": "italiano",
+			"site": [
+				{
+					"url": "http://it.wikipedia.org",
+					"dbname": "itwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://it.wiktionary.org",
+					"dbname": "itwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikizionario"
+				},
+				{
+					"url": "http://it.wikibooks.org",
+					"dbname": "itwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://it.wikinews.org",
+					"dbname": "itwikinews",
+					"code": "wikinews",
+					"sitename": "Wikinotizie"
+				},
+				{
+					"url": "http://it.wikiquote.org",
+					"dbname": "itwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://it.wikisource.org",
+					"dbname": "itwikisource",
+					"code": "wikisource",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://it.wikiversity.org",
+					"dbname": "itwikiversity",
+					"code": "wikiversity",
+					"sitename": "Wikiversità"
+				},
+				{
+					"url": "http://it.wikivoyage.org",
+					"dbname": "itwikivoyage",
+					"code": "wikivoyage",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Italian"
+		},
+		"112": {
+			"code": "iu",
+			"name": "ᐃᓄᒃᑎᑐᑦ/inuktitut",
+			"site": [
+				{
+					"url": "http://iu.wikipedia.org",
+					"dbname": "iuwiki",
+					"code": "wiki",
+					"sitename": "ᐅᐃᑭᐱᑎᐊ"
+				},
+				{
+					"url": "http://iu.wiktionary.org",
+					"dbname": "iuwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Inuktitut"
+		},
+		"113": {
+			"code": "ja",
+			"name": "日本語",
+			"site": [
+				{
+					"url": "http://ja.wikipedia.org",
+					"dbname": "jawiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ja.wiktionary.org",
+					"dbname": "jawiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ja.wikibooks.org",
+					"dbname": "jawikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ja.wikinews.org",
+					"dbname": "jawikinews",
+					"code": "wikinews",
+					"sitename": "ウィキニュース"
+				},
+				{
+					"url": "http://ja.wikiquote.org",
+					"dbname": "jawikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ja.wikisource.org",
+					"dbname": "jawikisource",
+					"code": "wikisource",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ja.wikiversity.org",
+					"dbname": "jawikiversity",
+					"code": "wikiversity",
+					"sitename": "ウィキバーシティ"
+				}
+			],
+			"localname": "Japanese"
+		},
+		"114": {
+			"code": "jbo",
+			"name": "Lojban",
+			"site": [
+				{
+					"url": "http://jbo.wikipedia.org",
+					"dbname": "jbowiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://jbo.wiktionary.org",
+					"dbname": "jbowiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Lojban"
+		},
+		"115": {
+			"code": "jv",
+			"name": "Basa Jawa",
+			"site": [
+				{
+					"url": "http://jv.wikipedia.org",
+					"dbname": "jvwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://jv.wiktionary.org",
+					"dbname": "jvwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Javanese"
+		},
+		"116": {
+			"code": "ka",
+			"name": "ქართული",
+			"site": [
+				{
+					"url": "http://ka.wikipedia.org",
+					"dbname": "kawiki",
+					"code": "wiki",
+					"sitename": "ვიკიპედია"
+				},
+				{
+					"url": "http://ka.wiktionary.org",
+					"dbname": "kawiktionary",
+					"code": "wiktionary",
+					"sitename": "ვიქსიკონი"
+				},
+				{
+					"url": "http://ka.wikibooks.org",
+					"dbname": "kawikibooks",
+					"code": "wikibooks",
+					"sitename": "ვიკიწიგნები"
+				},
+				{
+					"url": "http://ka.wikiquote.org",
+					"dbname": "kawikiquote",
+					"code": "wikiquote",
+					"sitename": "ვიკიციტატა"
+				}
+			],
+			"localname": "Georgian"
+		},
+		"117": {
+			"code": "kaa",
+			"name": "Qaraqalpaqsha",
+			"site": [
+				{
+					"url": "http://kaa.wikipedia.org",
+					"dbname": "kaawiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Kara-Kalpak"
+		},
+		"118": {
+			"code": "kab",
+			"name": "Taqbaylit",
+			"site": [
+				{
+					"url": "http://kab.wikipedia.org",
+					"dbname": "kabwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Kabyle"
+		},
+		"119": {
+			"code": "kbd",
+			"name": "Адыгэбзэ",
+			"site": [
+				{
+					"url": "http://kbd.wikipedia.org",
+					"dbname": "kbdwiki",
+					"code": "wiki",
+					"sitename": "Уикипедиэ"
+				}
+			],
+			"localname": "Kabardian"
+		},
+		"120": {
+			"code": "kg",
+			"name": "Kongo",
+			"site": [
+				{
+					"url": "http://kg.wikipedia.org",
+					"dbname": "kgwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Kongo"
+		},
+		"121": {
+			"code": "ki",
+			"name": "Gĩkũyũ",
+			"site": [
+				{
+					"url": "http://ki.wikipedia.org",
+					"dbname": "kiwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Kikuyu"
+		},
+		"122": {
+			"code": "kj",
+			"name": "Kwanyama",
+			"site": [
+				{
+					"url": "http://kj.wikipedia.org",
+					"dbname": "kjwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Kuanyama"
+		},
+		"123": {
+			"code": "kk",
+			"name": "қазақша",
+			"site": [
+				{
+					"url": "http://kk.wikipedia.org",
+					"dbname": "kkwiki",
+					"code": "wiki",
+					"sitename": "Уикипедия"
+				},
+				{
+					"url": "http://kk.wiktionary.org",
+					"dbname": "kkwiktionary",
+					"code": "wiktionary",
+					"sitename": "Уикисөздік"
+				},
+				{
+					"url": "http://kk.wikibooks.org",
+					"dbname": "kkwikibooks",
+					"code": "wikibooks",
+					"sitename": "Уикикітап"
+				},
+				{
+					"url": "http://kk.wikiquote.org",
+					"dbname": "kkwikiquote",
+					"code": "wikiquote",
+					"sitename": "Уикидәйек",
+					"closed": ""
+				}
+			],
+			"localname": "Kazakh"
+		},
+		"124": {
+			"code": "kl",
+			"name": "kalaallisut",
+			"site": [
+				{
+					"url": "http://kl.wikipedia.org",
+					"dbname": "klwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://kl.wiktionary.org",
+					"dbname": "klwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Kalaallisut"
+		},
+		"125": {
+			"code": "km",
+			"name": "ភាសាខ្មែរ",
+			"site": [
+				{
+					"url": "http://km.wikipedia.org",
+					"dbname": "kmwiki",
+					"code": "wiki",
+					"sitename": "វិគីភីឌា"
+				},
+				{
+					"url": "http://km.wiktionary.org",
+					"dbname": "kmwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://km.wikibooks.org",
+					"dbname": "kmwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Khmer"
+		},
+		"126": {
+			"code": "kn",
+			"name": "ಕನ್ನಡ",
+			"site": [
+				{
+					"url": "http://kn.wikipedia.org",
+					"dbname": "knwiki",
+					"code": "wiki",
+					"sitename": "ವಿಕಿಪೀಡಿಯ"
+				},
+				{
+					"url": "http://kn.wiktionary.org",
+					"dbname": "knwiktionary",
+					"code": "wiktionary",
+					"sitename": "ವಿಕ್ಷನರಿ"
+				},
+				{
+					"url": "http://kn.wikibooks.org",
+					"dbname": "knwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://kn.wikiquote.org",
+					"dbname": "knwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://kn.wikisource.org",
+					"dbname": "knwikisource",
+					"code": "wikisource",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Kannada"
+		},
+		"127": {
+			"code": "ko",
+			"name": "한국어",
+			"site": [
+				{
+					"url": "http://ko.wikipedia.org",
+					"dbname": "kowiki",
+					"code": "wiki",
+					"sitename": "위키백과"
+				},
+				{
+					"url": "http://ko.wiktionary.org",
+					"dbname": "kowiktionary",
+					"code": "wiktionary",
+					"sitename": "위키낱말사전"
+				},
+				{
+					"url": "http://ko.wikibooks.org",
+					"dbname": "kowikibooks",
+					"code": "wikibooks",
+					"sitename": "위키책"
+				},
+				{
+					"url": "http://ko.wikinews.org",
+					"dbname": "kowikinews",
+					"code": "wikinews",
+					"sitename": "위키뉴스"
+				},
+				{
+					"url": "http://ko.wikiquote.org",
+					"dbname": "kowikiquote",
+					"code": "wikiquote",
+					"sitename": "위키인용집"
+				},
+				{
+					"url": "http://ko.wikisource.org",
+					"dbname": "kowikisource",
+					"code": "wikisource",
+					"sitename": "위키문헌"
+				},
+				{
+					"url": "http://ko.wikiversity.org",
+					"dbname": "kowikiversity",
+					"code": "wikiversity",
+					"sitename": "위키배움터"
+				}
+			],
+			"localname": "Korean"
+		},
+		"128": {
+			"code": "koi",
+			"name": "Перем Коми",
+			"site": [
+				{
+					"url": "http://koi.wikipedia.org",
+					"dbname": "koiwiki",
+					"code": "wiki",
+					"sitename": "Википедия"
+				}
+			],
+			"localname": "Komi-Permyak"
+		},
+		"129": {
+			"code": "kr",
+			"name": "Kanuri",
+			"site": [
+				{
+					"url": "http://kr.wikipedia.org",
+					"dbname": "krwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://kr.wikiquote.org",
+					"dbname": "krwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Kanuri"
+		},
+		"130": {
+			"code": "krc",
+			"name": "къарачай-малкъар",
+			"site": [
+				{
+					"url": "http://krc.wikipedia.org",
+					"dbname": "krcwiki",
+					"code": "wiki",
+					"sitename": "Википедия"
+				}
+			],
+			"localname": "Karachay-Balkar"
+		},
+		"131": {
+			"code": "ks",
+			"name": "कॉशुर / کٲشُر",
+			"site": [
+				{
+					"url": "http://ks.wikipedia.org",
+					"dbname": "kswiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ks.wiktionary.org",
+					"dbname": "kswiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ks.wikibooks.org",
+					"dbname": "kswikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://ks.wikiquote.org",
+					"dbname": "kswikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Kashmiri"
+		},
+		"132": {
+			"code": "ksh",
+			"name": "Ripoarisch",
+			"site": [
+				{
+					"url": "http://ksh.wikipedia.org",
+					"dbname": "kshwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Colognian"
+		},
+		"133": {
+			"code": "ku",
+			"name": "Kurdî",
+			"site": [
+				{
+					"url": "http://ku.wikipedia.org",
+					"dbname": "kuwiki",
+					"code": "wiki",
+					"sitename": "Wîkîpediya"
+				},
+				{
+					"url": "http://ku.wiktionary.org",
+					"dbname": "kuwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ku.wikibooks.org",
+					"dbname": "kuwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ku.wikiquote.org",
+					"dbname": "kuwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Kurdish"
+		},
+		"134": {
+			"code": "kv",
+			"name": "коми",
+			"site": [
+				{
+					"url": "http://kv.wikipedia.org",
+					"dbname": "kvwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Komi"
+		},
+		"135": {
+			"code": "kw",
+			"name": "kernowek",
+			"site": [
+				{
+					"url": "http://kw.wikipedia.org",
+					"dbname": "kwwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://kw.wiktionary.org",
+					"dbname": "kwwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://kw.wikiquote.org",
+					"dbname": "kwwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Cornish"
+		},
+		"136": {
+			"code": "ky",
+			"name": "Кыргызча",
+			"site": [
+				{
+					"url": "http://ky.wikipedia.org",
+					"dbname": "kywiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ky.wiktionary.org",
+					"dbname": "kywiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ky.wikibooks.org",
+					"dbname": "kywikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ky.wikiquote.org",
+					"dbname": "kywikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Kyrgyz"
+		},
+		"137": {
+			"code": "la",
+			"name": "Latina",
+			"site": [
+				{
+					"url": "http://la.wikipedia.org",
+					"dbname": "lawiki",
+					"code": "wiki",
+					"sitename": "Vicipaedia"
+				},
+				{
+					"url": "http://la.wiktionary.org",
+					"dbname": "lawiktionary",
+					"code": "wiktionary",
+					"sitename": "Victionarium"
+				},
+				{
+					"url": "http://la.wikibooks.org",
+					"dbname": "lawikibooks",
+					"code": "wikibooks",
+					"sitename": "Vicilibri"
+				},
+				{
+					"url": "http://la.wikiquote.org",
+					"dbname": "lawikiquote",
+					"code": "wikiquote",
+					"sitename": "Vicicitatio"
+				},
+				{
+					"url": "http://la.wikisource.org",
+					"dbname": "lawikisource",
+					"code": "wikisource",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Latin"
+		},
+		"138": {
+			"code": "lad",
+			"name": "Ladino",
+			"site": [
+				{
+					"url": "http://lad.wikipedia.org",
+					"dbname": "ladwiki",
+					"code": "wiki",
+					"sitename": "Vikipedya"
+				}
+			],
+			"localname": "Ladino"
+		},
+		"139": {
+			"code": "lb",
+			"name": "Lëtzebuergesch",
+			"site": [
+				{
+					"url": "http://lb.wikipedia.org",
+					"dbname": "lbwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://lb.wiktionary.org",
+					"dbname": "lbwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wiktionnaire"
+				},
+				{
+					"url": "http://lb.wikibooks.org",
+					"dbname": "lbwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://lb.wikiquote.org",
+					"dbname": "lbwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Luxembourgish"
+		},
+		"140": {
+			"code": "lbe",
+			"name": "лакку",
+			"site": [
+				{
+					"url": "http://lbe.wikipedia.org",
+					"dbname": "lbewiki",
+					"code": "wiki",
+					"sitename": "Википедия"
+				}
+			],
+			"localname": "лакку"
+		},
+		"141": {
+			"code": "lez",
+			"name": "лезги",
+			"site": [
+				{
+					"url": "http://lez.wikipedia.org",
+					"dbname": "lezwiki",
+					"code": "wiki",
+					"sitename": "Википедия"
+				}
+			],
+			"localname": "Lezghian"
+		},
+		"142": {
+			"code": "lg",
+			"name": "Luganda",
+			"site": [
+				{
+					"url": "http://lg.wikipedia.org",
+					"dbname": "lgwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Ganda"
+		},
+		"143": {
+			"code": "li",
+			"name": "Limburgs",
+			"site": [
+				{
+					"url": "http://li.wikipedia.org",
+					"dbname": "liwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://li.wiktionary.org",
+					"dbname": "liwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://li.wikibooks.org",
+					"dbname": "liwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikibeuk"
+				},
+				{
+					"url": "http://li.wikiquote.org",
+					"dbname": "liwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://li.wikisource.org",
+					"dbname": "liwikisource",
+					"code": "wikisource",
+					"sitename": "Wikibrónne"
+				}
+			],
+			"localname": "Limburgish"
+		},
+		"144": {
+			"code": "lij",
+			"name": "Ligure",
+			"site": [
+				{
+					"url": "http://lij.wikipedia.org",
+					"dbname": "lijwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Ligurian"
+		},
+		"145": {
+			"code": "lmo",
+			"name": "lumbaart",
+			"site": [
+				{
+					"url": "http://lmo.wikipedia.org",
+					"dbname": "lmowiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Lombard"
+		},
+		"146": {
+			"code": "ln",
+			"name": "lingála",
+			"site": [
+				{
+					"url": "http://ln.wikipedia.org",
+					"dbname": "lnwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ln.wiktionary.org",
+					"dbname": "lnwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ln.wikibooks.org",
+					"dbname": "lnwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Lingala"
+		},
+		"147": {
+			"code": "lo",
+			"name": "ລາວ",
+			"site": [
+				{
+					"url": "http://lo.wikipedia.org",
+					"dbname": "lowiki",
+					"code": "wiki",
+					"sitename": "ວິກິພີເດຍ"
+				},
+				{
+					"url": "http://lo.wiktionary.org",
+					"dbname": "lowiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Lao"
+		},
+		"148": {
+			"code": "lt",
+			"name": "lietuvių",
+			"site": [
+				{
+					"url": "http://lt.wikipedia.org",
+					"dbname": "ltwiki",
+					"code": "wiki",
+					"sitename": "Vikipedija"
+				},
+				{
+					"url": "http://lt.wiktionary.org",
+					"dbname": "ltwiktionary",
+					"code": "wiktionary",
+					"sitename": "Vikižodynas"
+				},
+				{
+					"url": "http://lt.wikibooks.org",
+					"dbname": "ltwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://lt.wikiquote.org",
+					"dbname": "ltwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://lt.wikisource.org",
+					"dbname": "ltwikisource",
+					"code": "wikisource",
+					"sitename": "Vikišaltiniai"
+				}
+			],
+			"localname": "Lithuanian"
+		},
+		"149": {
+			"code": "ltg",
+			"name": "latgaļu",
+			"site": [
+				{
+					"url": "http://ltg.wikipedia.org",
+					"dbname": "ltgwiki",
+					"code": "wiki",
+					"sitename": "Vikipedeja"
+				}
+			],
+			"localname": "Latgalian"
+		},
+		"150": {
+			"code": "lv",
+			"name": "latviešu",
+			"site": [
+				{
+					"url": "http://lv.wikipedia.org",
+					"dbname": "lvwiki",
+					"code": "wiki",
+					"sitename": "Vikipēdija"
+				},
+				{
+					"url": "http://lv.wiktionary.org",
+					"dbname": "lvwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://lv.wikibooks.org",
+					"dbname": "lvwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Latvian"
+		},
+		"151": {
+			"code": "mai",
+			"name": "मैथिली",
+			"site": [
+				{
+					"url": "http://mai.wikipedia.org",
+					"dbname": "maiwiki",
+					"code": "wiki",
+					"sitename": "विकिपिडिया"
+				}
+			],
+			"localname": "Maithili"
+		},
+		"152": {
+			"code": "map-bms",
+			"name": "Basa Banyumasan",
+			"site": [
+				{
+					"url": "http://map-bms.wikipedia.org",
+					"dbname": "map_bmswiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Basa Banyumasan"
+		},
+		"153": {
+			"code": "mdf",
+			"name": "мокшень",
+			"site": [
+				{
+					"url": "http://mdf.wikipedia.org",
+					"dbname": "mdfwiki",
+					"code": "wiki",
+					"sitename": "Википедиесь"
+				}
+			],
+			"localname": "Moksha"
+		},
+		"154": {
+			"code": "mg",
+			"name": "Malagasy",
+			"site": [
+				{
+					"url": "http://mg.wikipedia.org",
+					"dbname": "mgwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://mg.wiktionary.org",
+					"dbname": "mgwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://mg.wikibooks.org",
+					"dbname": "mgwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Malagasy"
+		},
+		"155": {
+			"code": "mh",
+			"name": "Ebon",
+			"site": [
+				{
+					"url": "http://mh.wikipedia.org",
+					"dbname": "mhwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://mh.wiktionary.org",
+					"dbname": "mhwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Marshallese"
+		},
+		"156": {
+			"code": "mhr",
+			"name": "олык марий",
+			"site": [
+				{
+					"url": "http://mhr.wikipedia.org",
+					"dbname": "mhrwiki",
+					"code": "wiki",
+					"sitename": "Википедий"
+				}
+			],
+			"localname": "Eastern Mari"
+		},
+		"157": {
+			"code": "mi",
+			"name": "Māori",
+			"site": [
+				{
+					"url": "http://mi.wikipedia.org",
+					"dbname": "miwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://mi.wiktionary.org",
+					"dbname": "miwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://mi.wikibooks.org",
+					"dbname": "miwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Maori"
+		},
+		"158": {
+			"code": "min",
+			"name": "Baso Minangkabau",
+			"site": [
+				{
+					"url": "http://min.wikipedia.org",
+					"dbname": "minwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Minangkabau"
+		},
+		"159": {
+			"code": "mk",
+			"name": "македонски",
+			"site": [
+				{
+					"url": "http://mk.wikipedia.org",
+					"dbname": "mkwiki",
+					"code": "wiki",
+					"sitename": "Википедија"
+				},
+				{
+					"url": "http://mk.wiktionary.org",
+					"dbname": "mkwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://mk.wikibooks.org",
+					"dbname": "mkwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://mk.wikisource.org",
+					"dbname": "mkwikisource",
+					"code": "wikisource",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Macedonian"
+		},
+		"160": {
+			"code": "ml",
+			"name": "മലയാളം",
+			"site": [
+				{
+					"url": "http://ml.wikipedia.org",
+					"dbname": "mlwiki",
+					"code": "wiki",
+					"sitename": "വിക്കിപീഡിയ"
+				},
+				{
+					"url": "http://ml.wiktionary.org",
+					"dbname": "mlwiktionary",
+					"code": "wiktionary",
+					"sitename": "വിക്കിനിഘണ്ടു"
+				},
+				{
+					"url": "http://ml.wikibooks.org",
+					"dbname": "mlwikibooks",
+					"code": "wikibooks",
+					"sitename": "വിക്കിപാഠശാല"
+				},
+				{
+					"url": "http://ml.wikiquote.org",
+					"dbname": "mlwikiquote",
+					"code": "wikiquote",
+					"sitename": "വിക്കിചൊല്ലുകൾ"
+				},
+				{
+					"url": "http://ml.wikisource.org",
+					"dbname": "mlwikisource",
+					"code": "wikisource",
+					"sitename": "വിക്കിഗ്രന്ഥശാല"
+				}
+			],
+			"localname": "Malayalam"
+		},
+		"161": {
+			"code": "mn",
+			"name": "монгол",
+			"site": [
+				{
+					"url": "http://mn.wikipedia.org",
+					"dbname": "mnwiki",
+					"code": "wiki",
+					"sitename": "Википедиа"
+				},
+				{
+					"url": "http://mn.wiktionary.org",
+					"dbname": "mnwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://mn.wikibooks.org",
+					"dbname": "mnwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Mongolian"
+		},
+		"162": {
+			"code": "mo",
+			"name": "молдовеняскэ",
+			"site": [
+				{
+					"url": "http://mo.wikipedia.org",
+					"dbname": "mowiki",
+					"code": "wiki",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://mo.wiktionary.org",
+					"dbname": "mowiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "молдовеняскэ"
+		},
+		"163": {
+			"code": "mr",
+			"name": "मराठी",
+			"site": [
+				{
+					"url": "http://mr.wikipedia.org",
+					"dbname": "mrwiki",
+					"code": "wiki",
+					"sitename": "विकिपीडिया"
+				},
+				{
+					"url": "http://mr.wiktionary.org",
+					"dbname": "mrwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://mr.wikibooks.org",
+					"dbname": "mrwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://mr.wikiquote.org",
+					"dbname": "mrwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://mr.wikisource.org",
+					"dbname": "mrwikisource",
+					"code": "wikisource",
+					"sitename": "विकिस्रोत"
+				}
+			],
+			"localname": "Marathi"
+		},
+		"164": {
+			"code": "mrj",
+			"name": "кырык мары",
+			"site": [
+				{
+					"url": "http://mrj.wikipedia.org",
+					"dbname": "mrjwiki",
+					"code": "wiki",
+					"sitename": "Википеди"
+				}
+			],
+			"localname": "Hill Mari"
+		},
+		"165": {
+			"code": "ms",
+			"name": "Bahasa Melayu",
+			"site": [
+				{
+					"url": "http://ms.wikipedia.org",
+					"dbname": "mswiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ms.wiktionary.org",
+					"dbname": "mswiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ms.wikibooks.org",
+					"dbname": "mswikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Malay"
+		},
+		"166": {
+			"code": "mt",
+			"name": "Malti",
+			"site": [
+				{
+					"url": "http://mt.wikipedia.org",
+					"dbname": "mtwiki",
+					"code": "wiki",
+					"sitename": "Wikipedija"
+				},
+				{
+					"url": "http://mt.wiktionary.org",
+					"dbname": "mtwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikizzjunarju"
+				}
+			],
+			"localname": "Maltese"
+		},
+		"167": {
+			"code": "mus",
+			"name": "Mvskoke",
+			"site": [
+				{
+					"url": "http://mus.wikipedia.org",
+					"dbname": "muswiki",
+					"code": "wiki",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Creek"
+		},
+		"168": {
+			"code": "mwl",
+			"name": "Mirandés",
+			"site": [
+				{
+					"url": "http://mwl.wikipedia.org",
+					"dbname": "mwlwiki",
+					"code": "wiki",
+					"sitename": "Biquipédia"
+				}
+			],
+			"localname": "Mirandese"
+		},
+		"169": {
+			"code": "my",
+			"name": "မြန်မာဘာသာ",
+			"site": [
+				{
+					"url": "http://my.wikipedia.org",
+					"dbname": "mywiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://my.wiktionary.org",
+					"dbname": "mywiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://my.wikibooks.org",
+					"dbname": "mywikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Burmese"
+		},
+		"170": {
+			"code": "myv",
+			"name": "эрзянь",
+			"site": [
+				{
+					"url": "http://myv.wikipedia.org",
+					"dbname": "myvwiki",
+					"code": "wiki",
+					"sitename": "Википедиясь"
+				}
+			],
+			"localname": "Erzya"
+		},
+		"171": {
+			"code": "mzn",
+			"name": "مازِرونی",
+			"site": [
+				{
+					"url": "http://mzn.wikipedia.org",
+					"dbname": "mznwiki",
+					"code": "wiki",
+					"sitename": "ویکی‌پدیا"
+				}
+			],
+			"localname": "Mazanderani"
+		},
+		"172": {
+			"code": "na",
+			"name": "Dorerin Naoero",
+			"site": [
+				{
+					"url": "http://na.wikipedia.org",
+					"dbname": "nawiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://na.wiktionary.org",
+					"dbname": "nawiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://na.wikibooks.org",
+					"dbname": "nawikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://na.wikiquote.org",
+					"dbname": "nawikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Nauru"
+		},
+		"173": {
+			"code": "nah",
+			"name": "Nāhuatl",
+			"site": [
+				{
+					"url": "http://nah.wikipedia.org",
+					"dbname": "nahwiki",
+					"code": "wiki",
+					"sitename": "Huiquipedia"
+				},
+				{
+					"url": "http://nah.wiktionary.org",
+					"dbname": "nahwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://nah.wikibooks.org",
+					"dbname": "nahwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Nāhuatl"
+		},
+		"174": {
+			"code": "nap",
+			"name": "Napulitano",
+			"site": [
+				{
+					"url": "http://nap.wikipedia.org",
+					"dbname": "napwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Neapolitan"
+		},
+		"175": {
+			"code": "nds",
+			"name": "Plattdüütsch",
+			"site": [
+				{
+					"url": "http://nds.wikipedia.org",
+					"dbname": "ndswiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://nds.wiktionary.org",
+					"dbname": "ndswiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://nds.wikibooks.org",
+					"dbname": "ndswikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://nds.wikiquote.org",
+					"dbname": "ndswikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Low German"
+		},
+		"176": {
+			"code": "nds-nl",
+			"name": "Nedersaksies",
+			"site": [
+				{
+					"url": "http://nds-nl.wikipedia.org",
+					"dbname": "nds_nlwiki",
+					"code": "wiki",
+					"sitename": "Wikipedie"
+				}
+			],
+			"localname": "Low Saxon (Netherlands)"
+		},
+		"177": {
+			"code": "ne",
+			"name": "नेपाली",
+			"site": [
+				{
+					"url": "http://ne.wikipedia.org",
+					"dbname": "newiki",
+					"code": "wiki",
+					"sitename": "विकिपीडिया"
+				},
+				{
+					"url": "http://ne.wiktionary.org",
+					"dbname": "newiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ne.wikibooks.org",
+					"dbname": "newikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Nepali"
+		},
+		"178": {
+			"code": "new",
+			"name": "नेपाल भाषा",
+			"site": [
+				{
+					"url": "http://new.wikipedia.org",
+					"dbname": "newwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Newari"
+		},
+		"179": {
+			"code": "ng",
+			"name": "Oshiwambo",
+			"site": [
+				{
+					"url": "http://ng.wikipedia.org",
+					"dbname": "ngwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Ndonga"
+		},
+		"180": {
+			"code": "nl",
+			"name": "Nederlands",
+			"site": [
+				{
+					"url": "http://nl.wikipedia.org",
+					"dbname": "nlwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://nl.wiktionary.org",
+					"dbname": "nlwiktionary",
+					"code": "wiktionary",
+					"sitename": "WikiWoordenboek"
+				},
+				{
+					"url": "http://nl.wikibooks.org",
+					"dbname": "nlwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://nl.wikinews.org",
+					"dbname": "nlwikinews",
+					"code": "wikinews",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://nl.wikiquote.org",
+					"dbname": "nlwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://nl.wikisource.org",
+					"dbname": "nlwikisource",
+					"code": "wikisource",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://nl.wikivoyage.org",
+					"dbname": "nlwikivoyage",
+					"code": "wikivoyage",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Dutch"
+		},
+		"181": {
+			"code": "nn",
+			"name": "norsk nynorsk",
+			"site": [
+				{
+					"url": "http://nn.wikipedia.org",
+					"dbname": "nnwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://nn.wiktionary.org",
+					"dbname": "nnwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://nn.wikiquote.org",
+					"dbname": "nnwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Norwegian Nynorsk"
+		},
+		"182": {
+			"code": "no",
+			"name": "norsk bokmål",
+			"site": [
+				{
+					"url": "http://no.wikipedia.org",
+					"dbname": "nowiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://no.wiktionary.org",
+					"dbname": "nowiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://no.wikibooks.org",
+					"dbname": "nowikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikibøker"
+				},
+				{
+					"url": "http://no.wikinews.org",
+					"dbname": "nowikinews",
+					"code": "wikinews",
+					"sitename": "Wikinytt"
+				},
+				{
+					"url": "http://no.wikiquote.org",
+					"dbname": "nowikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://no.wikisource.org",
+					"dbname": "nowikisource",
+					"code": "wikisource",
+					"sitename": "Wikikilden"
+				}
+			],
+			"localname": "Norwegian (bokmål)"
+		},
+		"183": {
+			"code": "nov",
+			"name": "Novial",
+			"site": [
+				{
+					"url": "http://nov.wikipedia.org",
+					"dbname": "novwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Novial"
+		},
+		"184": {
+			"code": "nrm",
+			"name": "Nouormand",
+			"site": [
+				{
+					"url": "http://nrm.wikipedia.org",
+					"dbname": "nrmwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Nouormand"
+		},
+		"185": {
+			"code": "nso",
+			"name": "Sesotho sa Leboa",
+			"site": [
+				{
+					"url": "http://nso.wikipedia.org",
+					"dbname": "nsowiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Northern Sotho"
+		},
+		"186": {
+			"code": "nv",
+			"name": "Diné bizaad",
+			"site": [
+				{
+					"url": "http://nv.wikipedia.org",
+					"dbname": "nvwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Navajo"
+		},
+		"187": {
+			"code": "ny",
+			"name": "Chi-Chewa",
+			"site": [
+				{
+					"url": "http://ny.wikipedia.org",
+					"dbname": "nywiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Nyanja"
+		},
+		"188": {
+			"code": "oc",
+			"name": "occitan",
+			"site": [
+				{
+					"url": "http://oc.wikipedia.org",
+					"dbname": "ocwiki",
+					"code": "wiki",
+					"sitename": "Wikipèdia"
+				},
+				{
+					"url": "http://oc.wiktionary.org",
+					"dbname": "ocwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikiccionari"
+				},
+				{
+					"url": "http://oc.wikibooks.org",
+					"dbname": "ocwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikilibres"
+				}
+			],
+			"localname": "Occitan"
+		},
+		"189": {
+			"code": "om",
+			"name": "Oromoo",
+			"site": [
+				{
+					"url": "http://om.wikipedia.org",
+					"dbname": "omwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://om.wiktionary.org",
+					"dbname": "omwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Oromo"
+		},
+		"190": {
+			"code": "or",
+			"name": "ଓଡ଼ିଆ",
+			"site": [
+				{
+					"url": "http://or.wikipedia.org",
+					"dbname": "orwiki",
+					"code": "wiki",
+					"sitename": "ଉଇକିପିଡ଼ିଆ"
+				},
+				{
+					"url": "http://or.wiktionary.org",
+					"dbname": "orwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://or.wikisource.org",
+					"dbname": "orwikisource",
+					"code": "wikisource",
+					"sitename": "ଉଇକିପାଠାଗାର"
+				}
+			],
+			"localname": "Oriya"
+		},
+		"191": {
+			"code": "os",
+			"name": "Ирон",
+			"site": [
+				{
+					"url": "http://os.wikipedia.org",
+					"dbname": "oswiki",
+					"code": "wiki",
+					"sitename": "Википеди"
+				}
+			],
+			"localname": "Ossetic"
+		},
+		"192": {
+			"code": "pa",
+			"name": "ਪੰਜਾਬੀ",
+			"site": [
+				{
+					"url": "http://pa.wikipedia.org",
+					"dbname": "pawiki",
+					"code": "wiki",
+					"sitename": "ਵਿਕੀਪੀਡੀਆ"
+				},
+				{
+					"url": "http://pa.wiktionary.org",
+					"dbname": "pawiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://pa.wikibooks.org",
+					"dbname": "pawikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Punjabi"
+		},
+		"193": {
+			"code": "pag",
+			"name": "Pangasinan",
+			"site": [
+				{
+					"url": "http://pag.wikipedia.org",
+					"dbname": "pagwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Pangasinan"
+		},
+		"194": {
+			"code": "pam",
+			"name": "Kapampangan",
+			"site": [
+				{
+					"url": "http://pam.wikipedia.org",
+					"dbname": "pamwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Pampanga"
+		},
+		"195": {
+			"code": "pap",
+			"name": "Papiamentu",
+			"site": [
+				{
+					"url": "http://pap.wikipedia.org",
+					"dbname": "papwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Papiamento"
+		},
+		"196": {
+			"code": "pcd",
+			"name": "Picard",
+			"site": [
+				{
+					"url": "http://pcd.wikipedia.org",
+					"dbname": "pcdwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Picard"
+		},
+		"197": {
+			"code": "pdc",
+			"name": "Deitsch",
+			"site": [
+				{
+					"url": "http://pdc.wikipedia.org",
+					"dbname": "pdcwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Pennsylvania German"
+		},
+		"198": {
+			"code": "pfl",
+			"name": "Pälzisch",
+			"site": [
+				{
+					"url": "http://pfl.wikipedia.org",
+					"dbname": "pflwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Palatine German"
+		},
+		"199": {
+			"code": "pi",
+			"name": "पालि",
+			"site": [
+				{
+					"url": "http://pi.wikipedia.org",
+					"dbname": "piwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://pi.wiktionary.org",
+					"dbname": "piwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Pali"
+		},
+		"200": {
+			"code": "pih",
+			"name": "Norfuk / Pitkern",
+			"site": [
+				{
+					"url": "http://pih.wikipedia.org",
+					"dbname": "pihwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Norfuk / Pitkern"
+		},
+		"201": {
+			"code": "pl",
+			"name": "polski",
+			"site": [
+				{
+					"url": "http://pl.wikipedia.org",
+					"dbname": "plwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://pl.wiktionary.org",
+					"dbname": "plwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikisłownik"
+				},
+				{
+					"url": "http://pl.wikibooks.org",
+					"dbname": "plwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://pl.wikinews.org",
+					"dbname": "plwikinews",
+					"code": "wikinews",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://pl.wikiquote.org",
+					"dbname": "plwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikicytaty"
+				},
+				{
+					"url": "http://pl.wikisource.org",
+					"dbname": "plwikisource",
+					"code": "wikisource",
+					"sitename": "Wikiźródła"
+				},
+				{
+					"url": "http://pl.wikivoyage.org",
+					"dbname": "plwikivoyage",
+					"code": "wikivoyage",
+					"sitename": "Wikipodróże"
+				}
+			],
+			"localname": "Polish"
+		},
+		"202": {
+			"code": "pms",
+			"name": "Piemontèis",
+			"site": [
+				{
+					"url": "http://pms.wikipedia.org",
+					"dbname": "pmswiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Piedmontese"
+		},
+		"203": {
+			"code": "pnb",
+			"name": "پنجابی",
+			"site": [
+				{
+					"url": "http://pnb.wikipedia.org",
+					"dbname": "pnbwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://pnb.wiktionary.org",
+					"dbname": "pnbwiktionary",
+					"code": "wiktionary",
+					"sitename": "وکشنری"
+				}
+			],
+			"localname": "Western Punjabi"
+		},
+		"204": {
+			"code": "pnt",
+			"name": "Ποντιακά",
+			"site": [
+				{
+					"url": "http://pnt.wikipedia.org",
+					"dbname": "pntwiki",
+					"code": "wiki",
+					"sitename": "Βικιπαίδεια"
+				}
+			],
+			"localname": "Pontic"
+		},
+		"205": {
+			"code": "ps",
+			"name": "پښتو",
+			"site": [
+				{
+					"url": "http://ps.wikipedia.org",
+					"dbname": "pswiki",
+					"code": "wiki",
+					"sitename": "ويکيپېډيا"
+				},
+				{
+					"url": "http://ps.wiktionary.org",
+					"dbname": "pswiktionary",
+					"code": "wiktionary",
+					"sitename": "ويکيسيند"
+				},
+				{
+					"url": "http://ps.wikibooks.org",
+					"dbname": "pswikibooks",
+					"code": "wikibooks",
+					"sitename": "ويکيتابونه",
+					"closed": ""
+				}
+			],
+			"localname": "Pashto"
+		},
+		"206": {
+			"code": "pt",
+			"name": "português",
+			"site": [
+				{
+					"url": "http://pt.wikipedia.org",
+					"dbname": "ptwiki",
+					"code": "wiki",
+					"sitename": "Wikipédia"
+				},
+				{
+					"url": "http://pt.wiktionary.org",
+					"dbname": "ptwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikcionário"
+				},
+				{
+					"url": "http://pt.wikibooks.org",
+					"dbname": "ptwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikilivros"
+				},
+				{
+					"url": "http://pt.wikinews.org",
+					"dbname": "ptwikinews",
+					"code": "wikinews",
+					"sitename": "Wikinotícias"
+				},
+				{
+					"url": "http://pt.wikiquote.org",
+					"dbname": "ptwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://pt.wikisource.org",
+					"dbname": "ptwikisource",
+					"code": "wikisource",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://pt.wikiversity.org",
+					"dbname": "ptwikiversity",
+					"code": "wikiversity",
+					"sitename": "Wikiversidade"
+				},
+				{
+					"url": "http://pt.wikivoyage.org",
+					"dbname": "ptwikivoyage",
+					"code": "wikivoyage",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Portuguese"
+		},
+		"207": {
+			"code": "qu",
+			"name": "Runa Simi",
+			"site": [
+				{
+					"url": "http://qu.wikipedia.org",
+					"dbname": "quwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://qu.wiktionary.org",
+					"dbname": "quwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://qu.wikibooks.org",
+					"dbname": "quwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://qu.wikiquote.org",
+					"dbname": "quwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Quechua"
+		},
+		"208": {
+			"code": "rm",
+			"name": "rumantsch",
+			"site": [
+				{
+					"url": "http://rm.wikipedia.org",
+					"dbname": "rmwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://rm.wiktionary.org",
+					"dbname": "rmwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://rm.wikibooks.org",
+					"dbname": "rmwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Romansh"
+		},
+		"209": {
+			"code": "rmy",
+			"name": "Romani",
+			"site": [
+				{
+					"url": "http://rmy.wikipedia.org",
+					"dbname": "rmywiki",
+					"code": "wiki",
+					"sitename": "Vikipidiya"
+				}
+			],
+			"localname": "Romani"
+		},
+		"210": {
+			"code": "rn",
+			"name": "Kirundi",
+			"site": [
+				{
+					"url": "http://rn.wikipedia.org",
+					"dbname": "rnwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://rn.wiktionary.org",
+					"dbname": "rnwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Rundi"
+		},
+		"211": {
+			"code": "ro",
+			"name": "română",
+			"site": [
+				{
+					"url": "http://ro.wikipedia.org",
+					"dbname": "rowiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ro.wiktionary.org",
+					"dbname": "rowiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikționar"
+				},
+				{
+					"url": "http://ro.wikibooks.org",
+					"dbname": "rowikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikimanuale"
+				},
+				{
+					"url": "http://ro.wikinews.org",
+					"dbname": "rowikinews",
+					"code": "wikinews",
+					"sitename": "Wikiștiri"
+				},
+				{
+					"url": "http://ro.wikiquote.org",
+					"dbname": "rowikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikicitat"
+				},
+				{
+					"url": "http://ro.wikisource.org",
+					"dbname": "rowikisource",
+					"code": "wikisource",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ro.wikivoyage.org",
+					"dbname": "rowikivoyage",
+					"code": "wikivoyage",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Romanian"
+		},
+		"212": {
+			"code": "roa-rup",
+			"name": "armãneashti",
+			"site": [
+				{
+					"url": "http://roa-rup.wikipedia.org",
+					"dbname": "roa_rupwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://roa-rup.wiktionary.org",
+					"dbname": "roa_rupwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Aromanian"
+		},
+		"213": {
+			"code": "roa-tara",
+			"name": "tarandíne",
+			"site": [
+				{
+					"url": "http://roa-tara.wikipedia.org",
+					"dbname": "roa_tarawiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "tarandíne"
+		},
+		"214": {
+			"code": "ru",
+			"name": "русский",
+			"site": [
+				{
+					"url": "https://ru.wikipedia.org",
+					"dbname": "ruwiki",
+					"code": "wiki",
+					"sitename": "Википедия"
+				},
+				{
+					"url": "https://ru.wiktionary.org",
+					"dbname": "ruwiktionary",
+					"code": "wiktionary",
+					"sitename": "Викисловарь"
+				},
+				{
+					"url": "https://ru.wikibooks.org",
+					"dbname": "ruwikibooks",
+					"code": "wikibooks",
+					"sitename": "Викиучебник"
+				},
+				{
+					"url": "https://ru.wikinews.org",
+					"dbname": "ruwikinews",
+					"code": "wikinews",
+					"sitename": "Викиновости"
+				},
+				{
+					"url": "https://ru.wikiquote.org",
+					"dbname": "ruwikiquote",
+					"code": "wikiquote",
+					"sitename": "Викицитатник"
+				},
+				{
+					"url": "https://ru.wikisource.org",
+					"dbname": "ruwikisource",
+					"code": "wikisource",
+					"sitename": "Викитека"
+				},
+				{
+					"url": "https://ru.wikiversity.org",
+					"dbname": "ruwikiversity",
+					"code": "wikiversity",
+					"sitename": "Викиверситет"
+				},
+				{
+					"url": "https://ru.wikivoyage.org",
+					"dbname": "ruwikivoyage",
+					"code": "wikivoyage",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Russian"
+		},
+		"215": {
+			"code": "rue",
+			"name": "русиньскый",
+			"site": [
+				{
+					"url": "http://rue.wikipedia.org",
+					"dbname": "ruewiki",
+					"code": "wiki",
+					"sitename": "Вікіпедія"
+				}
+			],
+			"localname": "Rusyn"
+		},
+		"216": {
+			"code": "rw",
+			"name": "Kinyarwanda",
+			"site": [
+				{
+					"url": "http://rw.wikipedia.org",
+					"dbname": "rwwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://rw.wiktionary.org",
+					"dbname": "rwwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Kinyarwanda"
+		},
+		"217": {
+			"code": "sa",
+			"name": "संस्कृतम्",
+			"site": [
+				{
+					"url": "http://sa.wikipedia.org",
+					"dbname": "sawiki",
+					"code": "wiki",
+					"sitename": "विकिपीडिया"
+				},
+				{
+					"url": "http://sa.wiktionary.org",
+					"dbname": "sawiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://sa.wikibooks.org",
+					"dbname": "sawikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://sa.wikiquote.org",
+					"dbname": "sawikiquote",
+					"code": "wikiquote",
+					"sitename": "विकिसूक्तिः"
+				},
+				{
+					"url": "http://sa.wikisource.org",
+					"dbname": "sawikisource",
+					"code": "wikisource",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Sanskrit"
+		},
+		"218": {
+			"code": "sah",
+			"name": "саха тыла",
+			"site": [
+				{
+					"url": "http://sah.wikipedia.org",
+					"dbname": "sahwiki",
+					"code": "wiki",
+					"sitename": "Бикипиэдьийэ"
+				},
+				{
+					"url": "http://sah.wikisource.org",
+					"dbname": "sahwikisource",
+					"code": "wikisource",
+					"sitename": "Бикитиэкэ"
+				}
+			],
+			"localname": "Sakha"
+		},
+		"219": {
+			"code": "sc",
+			"name": "sardu",
+			"site": [
+				{
+					"url": "http://sc.wikipedia.org",
+					"dbname": "scwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://sc.wiktionary.org",
+					"dbname": "scwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Sardinian"
+		},
+		"220": {
+			"code": "scn",
+			"name": "sicilianu",
+			"site": [
+				{
+					"url": "http://scn.wikipedia.org",
+					"dbname": "scnwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://scn.wiktionary.org",
+					"dbname": "scnwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikizziunariu"
+				}
+			],
+			"localname": "Sicilian"
+		},
+		"221": {
+			"code": "sco",
+			"name": "Scots",
+			"site": [
+				{
+					"url": "http://sco.wikipedia.org",
+					"dbname": "scowiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Scots"
+		},
+		"222": {
+			"code": "sd",
+			"name": "سنڌي",
+			"site": [
+				{
+					"url": "http://sd.wikipedia.org",
+					"dbname": "sdwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://sd.wiktionary.org",
+					"dbname": "sdwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://sd.wikinews.org",
+					"dbname": "sdwikinews",
+					"code": "wikinews",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Sindhi"
+		},
+		"223": {
+			"code": "se",
+			"name": "sámegiella",
+			"site": [
+				{
+					"url": "http://se.wikipedia.org",
+					"dbname": "sewiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://se.wikibooks.org",
+					"dbname": "sewikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Northern Sami"
+		},
+		"224": {
+			"code": "sg",
+			"name": "Sängö",
+			"site": [
+				{
+					"url": "http://sg.wikipedia.org",
+					"dbname": "sgwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://sg.wiktionary.org",
+					"dbname": "sgwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Sango"
+		},
+		"225": {
+			"code": "sh",
+			"name": "srpskohrvatski / српскохрватски",
+			"site": [
+				{
+					"url": "http://sh.wikipedia.org",
+					"dbname": "shwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://sh.wiktionary.org",
+					"dbname": "shwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Serbo-Croatian"
+		},
+		"226": {
+			"code": "si",
+			"name": "සිංහල",
+			"site": [
+				{
+					"url": "http://si.wikipedia.org",
+					"dbname": "siwiki",
+					"code": "wiki",
+					"sitename": "විකිපීඩියා, නිදහස් විශ්වකෝෂය"
+				},
+				{
+					"url": "http://si.wiktionary.org",
+					"dbname": "siwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://si.wikibooks.org",
+					"dbname": "siwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Sinhala"
+		},
+		"227": {
+			"code": "simple",
+			"name": "Simple English",
+			"site": [
+				{
+					"url": "http://simple.wikipedia.org",
+					"dbname": "simplewiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://simple.wiktionary.org",
+					"dbname": "simplewiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://simple.wikibooks.org",
+					"dbname": "simplewikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://simple.wikiquote.org",
+					"dbname": "simplewikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Simple English"
+		},
+		"228": {
+			"code": "sk",
+			"name": "slovenčina",
+			"site": [
+				{
+					"url": "http://sk.wikipedia.org",
+					"dbname": "skwiki",
+					"code": "wiki",
+					"sitename": "Wikipédia"
+				},
+				{
+					"url": "http://sk.wiktionary.org",
+					"dbname": "skwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikislovník"
+				},
+				{
+					"url": "http://sk.wikibooks.org",
+					"dbname": "skwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikiknihy"
+				},
+				{
+					"url": "http://sk.wikiquote.org",
+					"dbname": "skwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikicitáty"
+				},
+				{
+					"url": "http://sk.wikisource.org",
+					"dbname": "skwikisource",
+					"code": "wikisource",
+					"sitename": "Wikizdroje"
+				}
+			],
+			"localname": "Slovak"
+		},
+		"229": {
+			"code": "sl",
+			"name": "slovenščina",
+			"site": [
+				{
+					"url": "http://sl.wikipedia.org",
+					"dbname": "slwiki",
+					"code": "wiki",
+					"sitename": "Wikipedija"
+				},
+				{
+					"url": "http://sl.wiktionary.org",
+					"dbname": "slwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikislovar"
+				},
+				{
+					"url": "http://sl.wikibooks.org",
+					"dbname": "slwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikiknjige"
+				},
+				{
+					"url": "http://sl.wikiquote.org",
+					"dbname": "slwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikinavedek"
+				},
+				{
+					"url": "http://sl.wikisource.org",
+					"dbname": "slwikisource",
+					"code": "wikisource",
+					"sitename": "Wikivir"
+				},
+				{
+					"url": "http://sl.wikiversity.org",
+					"dbname": "slwikiversity",
+					"code": "wikiversity",
+					"sitename": "Wikiverza"
+				}
+			],
+			"localname": "Slovenian"
+		},
+		"230": {
+			"code": "sm",
+			"name": "Gagana Samoa",
+			"site": [
+				{
+					"url": "http://sm.wikipedia.org",
+					"dbname": "smwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://sm.wiktionary.org",
+					"dbname": "smwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Samoan"
+		},
+		"231": {
+			"code": "sn",
+			"name": "chiShona",
+			"site": [
+				{
+					"url": "http://sn.wikipedia.org",
+					"dbname": "snwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://sn.wiktionary.org",
+					"dbname": "snwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Shona"
+		},
+		"232": {
+			"code": "so",
+			"name": "Soomaaliga",
+			"site": [
+				{
+					"url": "http://so.wikipedia.org",
+					"dbname": "sowiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://so.wiktionary.org",
+					"dbname": "sowiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Somali"
+		},
+		"233": {
+			"code": "sq",
+			"name": "shqip",
+			"site": [
+				{
+					"url": "http://sq.wikipedia.org",
+					"dbname": "sqwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://sq.wiktionary.org",
+					"dbname": "sqwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://sq.wikibooks.org",
+					"dbname": "sqwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://sq.wikinews.org",
+					"dbname": "sqwikinews",
+					"code": "wikinews",
+					"sitename": "Wikilajme"
+				},
+				{
+					"url": "http://sq.wikiquote.org",
+					"dbname": "sqwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Albanian"
+		},
+		"234": {
+			"code": "sr",
+			"name": "српски / srpski",
+			"site": [
+				{
+					"url": "http://sr.wikipedia.org",
+					"dbname": "srwiki",
+					"code": "wiki",
+					"sitename": "Википедија"
+				},
+				{
+					"url": "http://sr.wiktionary.org",
+					"dbname": "srwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://sr.wikibooks.org",
+					"dbname": "srwikibooks",
+					"code": "wikibooks",
+					"sitename": "Викикњиге"
+				},
+				{
+					"url": "http://sr.wikinews.org",
+					"dbname": "srwikinews",
+					"code": "wikinews",
+					"sitename": "Викивести"
+				},
+				{
+					"url": "http://sr.wikiquote.org",
+					"dbname": "srwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://sr.wikisource.org",
+					"dbname": "srwikisource",
+					"code": "wikisource",
+					"sitename": "Викизворник"
+				}
+			],
+			"localname": "Serbian"
+		},
+		"235": {
+			"code": "srn",
+			"name": "Sranantongo",
+			"site": [
+				{
+					"url": "http://srn.wikipedia.org",
+					"dbname": "srnwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Sranan Tongo"
+		},
+		"236": {
+			"code": "ss",
+			"name": "SiSwati",
+			"site": [
+				{
+					"url": "http://ss.wikipedia.org",
+					"dbname": "sswiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ss.wiktionary.org",
+					"dbname": "sswiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Swati"
+		},
+		"237": {
+			"code": "st",
+			"name": "Sesotho",
+			"site": [
+				{
+					"url": "http://st.wikipedia.org",
+					"dbname": "stwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://st.wiktionary.org",
+					"dbname": "stwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Southern Sotho"
+		},
+		"238": {
+			"code": "stq",
+			"name": "Seeltersk",
+			"site": [
+				{
+					"url": "http://stq.wikipedia.org",
+					"dbname": "stqwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Saterland Frisian"
+		},
+		"239": {
+			"code": "su",
+			"name": "Basa Sunda",
+			"site": [
+				{
+					"url": "http://su.wikipedia.org",
+					"dbname": "suwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://su.wiktionary.org",
+					"dbname": "suwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://su.wikibooks.org",
+					"dbname": "suwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://su.wikiquote.org",
+					"dbname": "suwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Sundanese"
+		},
+		"240": {
+			"code": "sv",
+			"name": "svenska",
+			"site": [
+				{
+					"url": "http://sv.wikipedia.org",
+					"dbname": "svwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://sv.wiktionary.org",
+					"dbname": "svwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://sv.wikibooks.org",
+					"dbname": "svwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://sv.wikinews.org",
+					"dbname": "svwikinews",
+					"code": "wikinews",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://sv.wikiquote.org",
+					"dbname": "svwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://sv.wikisource.org",
+					"dbname": "svwikisource",
+					"code": "wikisource",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://sv.wikiversity.org",
+					"dbname": "svwikiversity",
+					"code": "wikiversity",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://sv.wikivoyage.org",
+					"dbname": "svwikivoyage",
+					"code": "wikivoyage",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Swedish"
+		},
+		"241": {
+			"code": "sw",
+			"name": "Kiswahili",
+			"site": [
+				{
+					"url": "http://sw.wikipedia.org",
+					"dbname": "swwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://sw.wiktionary.org",
+					"dbname": "swwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://sw.wikibooks.org",
+					"dbname": "swwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Swahili"
+		},
+		"242": {
+			"code": "szl",
+			"name": "ślůnski",
+			"site": [
+				{
+					"url": "http://szl.wikipedia.org",
+					"dbname": "szlwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Silesian"
+		},
+		"243": {
+			"code": "ta",
+			"name": "தமிழ்",
+			"site": [
+				{
+					"url": "http://ta.wikipedia.org",
+					"dbname": "tawiki",
+					"code": "wiki",
+					"sitename": "விக்கிப்பீடியா"
+				},
+				{
+					"url": "http://ta.wiktionary.org",
+					"dbname": "tawiktionary",
+					"code": "wiktionary",
+					"sitename": "விக்சனரி"
+				},
+				{
+					"url": "http://ta.wikibooks.org",
+					"dbname": "tawikibooks",
+					"code": "wikibooks",
+					"sitename": "விக்கிநூல்கள்"
+				},
+				{
+					"url": "http://ta.wikinews.org",
+					"dbname": "tawikinews",
+					"code": "wikinews",
+					"sitename": "விக்கிசெய்தி"
+				},
+				{
+					"url": "http://ta.wikiquote.org",
+					"dbname": "tawikiquote",
+					"code": "wikiquote",
+					"sitename": "விக்கிமேற்கோள்"
+				},
+				{
+					"url": "http://ta.wikisource.org",
+					"dbname": "tawikisource",
+					"code": "wikisource",
+					"sitename": "விக்கிமூலம்"
+				}
+			],
+			"localname": "Tamil"
+		},
+		"244": {
+			"code": "te",
+			"name": "తెలుగు",
+			"site": [
+				{
+					"url": "http://te.wikipedia.org",
+					"dbname": "tewiki",
+					"code": "wiki",
+					"sitename": "వికీపీడియా"
+				},
+				{
+					"url": "http://te.wiktionary.org",
+					"dbname": "tewiktionary",
+					"code": "wiktionary",
+					"sitename": "విక్షనరీ"
+				},
+				{
+					"url": "http://te.wikibooks.org",
+					"dbname": "tewikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://te.wikiquote.org",
+					"dbname": "tewikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://te.wikisource.org",
+					"dbname": "tewikisource",
+					"code": "wikisource",
+					"sitename": "వికీసోర్స్"
+				}
+			],
+			"localname": "Telugu"
+		},
+		"245": {
+			"code": "tet",
+			"name": "tetun",
+			"site": [
+				{
+					"url": "http://tet.wikipedia.org",
+					"dbname": "tetwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Tetum"
+		},
+		"246": {
+			"code": "tg",
+			"name": "тоҷикӣ",
+			"site": [
+				{
+					"url": "http://tg.wikipedia.org",
+					"dbname": "tgwiki",
+					"code": "wiki",
+					"sitename": "Википедиа"
+				},
+				{
+					"url": "http://tg.wiktionary.org",
+					"dbname": "tgwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://tg.wikibooks.org",
+					"dbname": "tgwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Tajik"
+		},
+		"247": {
+			"code": "th",
+			"name": "ไทย",
+			"site": [
+				{
+					"url": "http://th.wikipedia.org",
+					"dbname": "thwiki",
+					"code": "wiki",
+					"sitename": "วิกิพีเดีย"
+				},
+				{
+					"url": "http://th.wiktionary.org",
+					"dbname": "thwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://th.wikibooks.org",
+					"dbname": "thwikibooks",
+					"code": "wikibooks",
+					"sitename": "วิกิตำรา"
+				},
+				{
+					"url": "http://th.wikinews.org",
+					"dbname": "thwikinews",
+					"code": "wikinews",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://th.wikiquote.org",
+					"dbname": "thwikiquote",
+					"code": "wikiquote",
+					"sitename": "วิกิคำคม"
+				},
+				{
+					"url": "http://th.wikisource.org",
+					"dbname": "thwikisource",
+					"code": "wikisource",
+					"sitename": "วิกิซอร์ซ"
+				}
+			],
+			"localname": "Thai"
+		},
+		"248": {
+			"code": "ti",
+			"name": "ትግርኛ",
+			"site": [
+				{
+					"url": "http://ti.wikipedia.org",
+					"dbname": "tiwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ti.wiktionary.org",
+					"dbname": "tiwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Tigrinya"
+		},
+		"249": {
+			"code": "tk",
+			"name": "Türkmençe",
+			"site": [
+				{
+					"url": "http://tk.wikipedia.org",
+					"dbname": "tkwiki",
+					"code": "wiki",
+					"sitename": "Wikipediýa"
+				},
+				{
+					"url": "http://tk.wiktionary.org",
+					"dbname": "tkwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikisözlük"
+				},
+				{
+					"url": "http://tk.wikibooks.org",
+					"dbname": "tkwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://tk.wikiquote.org",
+					"dbname": "tkwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Turkmen"
+		},
+		"250": {
+			"code": "tl",
+			"name": "Tagalog",
+			"site": [
+				{
+					"url": "http://tl.wikipedia.org",
+					"dbname": "tlwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://tl.wiktionary.org",
+					"dbname": "tlwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://tl.wikibooks.org",
+					"dbname": "tlwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Tagalog"
+		},
+		"251": {
+			"code": "tn",
+			"name": "Setswana",
+			"site": [
+				{
+					"url": "http://tn.wikipedia.org",
+					"dbname": "tnwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://tn.wiktionary.org",
+					"dbname": "tnwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Tswana"
+		},
+		"252": {
+			"code": "to",
+			"name": "lea faka-Tonga",
+			"site": [
+				{
+					"url": "http://to.wikipedia.org",
+					"dbname": "towiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://to.wiktionary.org",
+					"dbname": "towiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Tongan"
+		},
+		"253": {
+			"code": "tpi",
+			"name": "Tok Pisin",
+			"site": [
+				{
+					"url": "http://tpi.wikipedia.org",
+					"dbname": "tpiwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://tpi.wiktionary.org",
+					"dbname": "tpiwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Tok Pisin"
+		},
+		"254": {
+			"code": "tr",
+			"name": "Türkçe",
+			"site": [
+				{
+					"url": "http://tr.wikipedia.org",
+					"dbname": "trwiki",
+					"code": "wiki",
+					"sitename": "Vikipedi"
+				},
+				{
+					"url": "http://tr.wiktionary.org",
+					"dbname": "trwiktionary",
+					"code": "wiktionary",
+					"sitename": "Vikisözlük"
+				},
+				{
+					"url": "http://tr.wikibooks.org",
+					"dbname": "trwikibooks",
+					"code": "wikibooks",
+					"sitename": "Vikikitap"
+				},
+				{
+					"url": "http://tr.wikinews.org",
+					"dbname": "trwikinews",
+					"code": "wikinews",
+					"sitename": "Vikihaber"
+				},
+				{
+					"url": "http://tr.wikiquote.org",
+					"dbname": "trwikiquote",
+					"code": "wikiquote",
+					"sitename": "Vikisöz"
+				},
+				{
+					"url": "http://tr.wikisource.org",
+					"dbname": "trwikisource",
+					"code": "wikisource",
+					"sitename": "Vikikaynak"
+				}
+			],
+			"localname": "Turkish"
+		},
+		"255": {
+			"code": "ts",
+			"name": "Xitsonga",
+			"site": [
+				{
+					"url": "http://ts.wikipedia.org",
+					"dbname": "tswiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ts.wiktionary.org",
+					"dbname": "tswiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Tsonga"
+		},
+		"256": {
+			"code": "tt",
+			"name": "татарча/tatarça",
+			"site": [
+				{
+					"url": "http://tt.wikipedia.org",
+					"dbname": "ttwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://tt.wiktionary.org",
+					"dbname": "ttwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://tt.wikibooks.org",
+					"dbname": "ttwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://tt.wikiquote.org",
+					"dbname": "ttwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Tatar"
+		},
+		"257": {
+			"code": "tum",
+			"name": "chiTumbuka",
+			"site": [
+				{
+					"url": "http://tum.wikipedia.org",
+					"dbname": "tumwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Tumbuka"
+		},
+		"258": {
+			"code": "tw",
+			"name": "Twi",
+			"site": [
+				{
+					"url": "http://tw.wikipedia.org",
+					"dbname": "twwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://tw.wiktionary.org",
+					"dbname": "twwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Twi"
+		},
+		"259": {
+			"code": "ty",
+			"name": "reo tahiti",
+			"site": [
+				{
+					"url": "http://ty.wikipedia.org",
+					"dbname": "tywiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Tahitian"
+		},
+		"260": {
+			"code": "tyv",
+			"name": "тыва дыл",
+			"site": [
+				{
+					"url": "http://tyv.wikipedia.org",
+					"dbname": "tyvwiki",
+					"code": "wiki",
+					"sitename": "Википедия"
+				}
+			],
+			"localname": "Tuvinian"
+		},
+		"261": {
+			"code": "udm",
+			"name": "удмурт",
+			"site": [
+				{
+					"url": "http://udm.wikipedia.org",
+					"dbname": "udmwiki",
+					"code": "wiki",
+					"sitename": "Википедия"
+				}
+			],
+			"localname": "Udmurt"
+		},
+		"262": {
+			"code": "ug",
+			"name": "ئۇيغۇرچە / Uyghurche",
+			"site": [
+				{
+					"url": "http://ug.wikipedia.org",
+					"dbname": "ugwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ug.wiktionary.org",
+					"dbname": "ugwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://ug.wikibooks.org",
+					"dbname": "ugwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://ug.wikiquote.org",
+					"dbname": "ugwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Uyghur"
+		},
+		"263": {
+			"code": "uk",
+			"name": "українська",
+			"site": [
+				{
+					"url": "http://uk.wikipedia.org",
+					"dbname": "ukwiki",
+					"code": "wiki",
+					"sitename": "Вікіпедія"
+				},
+				{
+					"url": "http://uk.wiktionary.org",
+					"dbname": "ukwiktionary",
+					"code": "wiktionary",
+					"sitename": "Вікісловник"
+				},
+				{
+					"url": "http://uk.wikibooks.org",
+					"dbname": "ukwikibooks",
+					"code": "wikibooks",
+					"sitename": "Вікіпідручник"
+				},
+				{
+					"url": "http://uk.wikinews.org",
+					"dbname": "ukwikinews",
+					"code": "wikinews",
+					"sitename": "Вікіновини"
+				},
+				{
+					"url": "http://uk.wikiquote.org",
+					"dbname": "ukwikiquote",
+					"code": "wikiquote",
+					"sitename": "Вікіцитати"
+				},
+				{
+					"url": "http://uk.wikisource.org",
+					"dbname": "ukwikisource",
+					"code": "wikisource",
+					"sitename": "Вікіджерела"
+				},
+				{
+					"url": "http://uk.wikivoyage.org",
+					"dbname": "ukwikivoyage",
+					"code": "wikivoyage",
+					"sitename": "Вікімандри"
+				}
+			],
+			"localname": "Ukrainian"
+		},
+		"264": {
+			"code": "ur",
+			"name": "اردو",
+			"site": [
+				{
+					"url": "http://ur.wikipedia.org",
+					"dbname": "urwiki",
+					"code": "wiki",
+					"sitename": "ویکیپیڈیا"
+				},
+				{
+					"url": "http://ur.wiktionary.org",
+					"dbname": "urwiktionary",
+					"code": "wiktionary",
+					"sitename": "وکی لغت"
+				},
+				{
+					"url": "http://ur.wikibooks.org",
+					"dbname": "urwikibooks",
+					"code": "wikibooks",
+					"sitename": "وکی کتب"
+				},
+				{
+					"url": "http://ur.wikiquote.org",
+					"dbname": "urwikiquote",
+					"code": "wikiquote",
+					"sitename": "وکی اقتباسات"
+				}
+			],
+			"localname": "Urdu"
+		},
+		"265": {
+			"code": "uz",
+			"name": "oʻzbekcha/ўзбекча",
+			"site": [
+				{
+					"url": "https://uz.wikipedia.org",
+					"dbname": "uzwiki",
+					"code": "wiki",
+					"sitename": "Vikipediya"
+				},
+				{
+					"url": "http://uz.wiktionary.org",
+					"dbname": "uzwiktionary",
+					"code": "wiktionary",
+					"sitename": "Vikilug‘at"
+				},
+				{
+					"url": "http://uz.wikibooks.org",
+					"dbname": "uzwikibooks",
+					"code": "wikibooks",
+					"sitename": "Vikikitob",
+					"closed": ""
+				},
+				{
+					"url": "http://uz.wikiquote.org",
+					"dbname": "uzwikiquote",
+					"code": "wikiquote",
+					"sitename": "Vikiiqtibos"
+				}
+			],
+			"localname": "Uzbek"
+		},
+		"266": {
+			"code": "ve",
+			"name": "Tshivenda",
+			"site": [
+				{
+					"url": "http://ve.wikipedia.org",
+					"dbname": "vewiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Venda"
+		},
+		"267": {
+			"code": "vec",
+			"name": "vèneto",
+			"site": [
+				{
+					"url": "http://vec.wikipedia.org",
+					"dbname": "vecwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://vec.wiktionary.org",
+					"dbname": "vecwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikisionario"
+				},
+				{
+					"url": "http://vec.wikisource.org",
+					"dbname": "vecwikisource",
+					"code": "wikisource",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Venetian"
+		},
+		"268": {
+			"code": "vep",
+			"name": "vepsän kel’",
+			"site": [
+				{
+					"url": "http://vep.wikipedia.org",
+					"dbname": "vepwiki",
+					"code": "wiki",
+					"sitename": "Vikipedii"
+				}
+			],
+			"localname": "Veps"
+		},
+		"269": {
+			"code": "vi",
+			"name": "Tiếng Việt",
+			"site": [
+				{
+					"url": "http://vi.wikipedia.org",
+					"dbname": "viwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://vi.wiktionary.org",
+					"dbname": "viwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://vi.wikibooks.org",
+					"dbname": "viwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://vi.wikiquote.org",
+					"dbname": "viwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://vi.wikisource.org",
+					"dbname": "viwikisource",
+					"code": "wikisource",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://vi.wikivoyage.org",
+					"dbname": "viwikivoyage",
+					"code": "wikivoyage",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Vietnamese"
+		},
+		"270": {
+			"code": "vls",
+			"name": "West-Vlams",
+			"site": [
+				{
+					"url": "http://vls.wikipedia.org",
+					"dbname": "vlswiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "West Flemish"
+		},
+		"271": {
+			"code": "vo",
+			"name": "Volapük",
+			"site": [
+				{
+					"url": "http://vo.wikipedia.org",
+					"dbname": "vowiki",
+					"code": "wiki",
+					"sitename": "Vükiped"
+				},
+				{
+					"url": "http://vo.wiktionary.org",
+					"dbname": "vowiktionary",
+					"code": "wiktionary",
+					"sitename": "Vükivödabuk"
+				},
+				{
+					"url": "http://vo.wikibooks.org",
+					"dbname": "vowikibooks",
+					"code": "wikibooks",
+					"sitename": "Vükibuks",
+					"closed": ""
+				},
+				{
+					"url": "http://vo.wikiquote.org",
+					"dbname": "vowikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Volapük"
+		},
+		"272": {
+			"code": "wa",
+			"name": "walon",
+			"site": [
+				{
+					"url": "http://wa.wikipedia.org",
+					"dbname": "wawiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://wa.wiktionary.org",
+					"dbname": "wawiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://wa.wikibooks.org",
+					"dbname": "wawikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Walloon"
+		},
+		"273": {
+			"code": "war",
+			"name": "Winaray",
+			"site": [
+				{
+					"url": "http://war.wikipedia.org",
+					"dbname": "warwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Waray"
+		},
+		"274": {
+			"code": "wo",
+			"name": "Wolof",
+			"site": [
+				{
+					"url": "http://wo.wikipedia.org",
+					"dbname": "wowiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://wo.wiktionary.org",
+					"dbname": "wowiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://wo.wikiquote.org",
+					"dbname": "wowikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Wolof"
+		},
+		"275": {
+			"code": "wuu",
+			"name": "吴语",
+			"site": [
+				{
+					"url": "http://wuu.wikipedia.org",
+					"dbname": "wuuwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Wu"
+		},
+		"276": {
+			"code": "xal",
+			"name": "хальмг",
+			"site": [
+				{
+					"url": "http://xal.wikipedia.org",
+					"dbname": "xalwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Kalmyk"
+		},
+		"277": {
+			"code": "xh",
+			"name": "isiXhosa",
+			"site": [
+				{
+					"url": "http://xh.wikipedia.org",
+					"dbname": "xhwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://xh.wiktionary.org",
+					"dbname": "xhwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://xh.wikibooks.org",
+					"dbname": "xhwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Xhosa"
+		},
+		"278": {
+			"code": "xmf",
+			"name": "მარგალური",
+			"site": [
+				{
+					"url": "http://xmf.wikipedia.org",
+					"dbname": "xmfwiki",
+					"code": "wiki",
+					"sitename": "ვიკიპედია"
+				}
+			],
+			"localname": "Mingrelian"
+		},
+		"279": {
+			"code": "yi",
+			"name": "ייִדיש",
+			"site": [
+				{
+					"url": "http://yi.wikipedia.org",
+					"dbname": "yiwiki",
+					"code": "wiki",
+					"sitename": "װיקיפּעדיע"
+				},
+				{
+					"url": "http://yi.wiktionary.org",
+					"dbname": "yiwiktionary",
+					"code": "wiktionary",
+					"sitename": "װיקיװערטערבוך"
+				},
+				{
+					"url": "http://yi.wikisource.org",
+					"dbname": "yiwikisource",
+					"code": "wikisource",
+					"sitename": "װיקיביבליאָטעק"
+				}
+			],
+			"localname": "Yiddish"
+		},
+		"280": {
+			"code": "yo",
+			"name": "Yorùbá",
+			"site": [
+				{
+					"url": "http://yo.wikipedia.org",
+					"dbname": "yowiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://yo.wiktionary.org",
+					"dbname": "yowiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://yo.wikibooks.org",
+					"dbname": "yowikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Yoruba"
+		},
+		"281": {
+			"code": "za",
+			"name": "Vahcuengh",
+			"site": [
+				{
+					"url": "http://za.wikipedia.org",
+					"dbname": "zawiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://za.wiktionary.org",
+					"dbname": "zawiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://za.wikibooks.org",
+					"dbname": "zawikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://za.wikiquote.org",
+					"dbname": "zawikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Zhuang"
+		},
+		"282": {
+			"code": "zea",
+			"name": "Zeêuws",
+			"site": [
+				{
+					"url": "http://zea.wikipedia.org",
+					"dbname": "zeawiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Zeeuws"
+		},
+		"283": {
+			"code": "zh",
+			"name": "中文",
+			"site": [
+				{
+					"url": "http://zh.wikipedia.org",
+					"dbname": "zhwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://zh.wiktionary.org",
+					"dbname": "zhwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://zh.wikibooks.org",
+					"dbname": "zhwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://zh.wikinews.org",
+					"dbname": "zhwikinews",
+					"code": "wikinews",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://zh.wikiquote.org",
+					"dbname": "zhwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://zh.wikisource.org",
+					"dbname": "zhwikisource",
+					"code": "wikisource",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://zh.wikivoyage.org",
+					"dbname": "zhwikivoyage",
+					"code": "wikivoyage",
+					"sitename": "维基导游"
+				}
+			],
+			"localname": "Chinese"
+		},
+		"284": {
+			"code": "zh-classical",
+			"name": "文言",
+			"site": [
+				{
+					"url": "http://zh-classical.wikipedia.org",
+					"dbname": "zh_classicalwiki",
+					"code": "wiki",
+					"sitename": "維基大典"
+				}
+			],
+			"localname": "Classical Chinese"
+		},
+		"285": {
+			"code": "zh-min-nan",
+			"name": "Bân-lâm-gú",
+			"site": [
+				{
+					"url": "http://zh-min-nan.wikipedia.org",
+					"dbname": "zh_min_nanwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://zh-min-nan.wiktionary.org",
+					"dbname": "zh_min_nanwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://zh-min-nan.wikibooks.org",
+					"dbname": "zh_min_nanwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://zh-min-nan.wikiquote.org",
+					"dbname": "zh_min_nanwikiquote",
+					"code": "wikiquote",
+					"sitename": "Wikipedia",
+					"closed": ""
+				},
+				{
+					"url": "http://zh-min-nan.wikisource.org",
+					"dbname": "zh_min_nanwikisource",
+					"code": "wikisource",
+					"sitename": "Wikipedia"
+				}
+			],
+			"localname": "Chinese (Min Nan)"
+		},
+		"286": {
+			"code": "zh-yue",
+			"name": "粵語",
+			"site": [
+				{
+					"url": "http://zh-yue.wikipedia.org",
+					"dbname": "zh_yuewiki",
+					"code": "wiki",
+					"sitename": "維基百科"
+				}
+			],
+			"localname": "Cantonese"
+		},
+		"287": {
+			"code": "zu",
+			"name": "isiZulu",
+			"site": [
+				{
+					"url": "http://zu.wikipedia.org",
+					"dbname": "zuwiki",
+					"code": "wiki",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://zu.wiktionary.org",
+					"dbname": "zuwiktionary",
+					"code": "wiktionary",
+					"sitename": "Wikipedia"
+				},
+				{
+					"url": "http://zu.wikibooks.org",
+					"dbname": "zuwikibooks",
+					"code": "wikibooks",
+					"sitename": "Wikipedia",
+					"closed": ""
+				}
+			],
+			"localname": "Zulu"
+		},
+		"count": 888,
+		"specials": [
+			{
+				"url": "http://advisory.wikimedia.org",
+				"dbname": "advisorywiki",
+				"code": "advisory",
+				"closed": ""
+			},
+			{
+				"url": "http://ar.wikimedia.org",
+				"dbname": "arwikimedia",
+				"code": "arwikimedia"
+			},
+			{
+				"url": "https://arbcom-de.wikipedia.org",
+				"dbname": "arbcom_dewiki",
+				"code": "arbcom-de",
+				"private": ""
+			},
+			{
+				"url": "https://arbcom-en.wikipedia.org",
+				"dbname": "arbcom_enwiki",
+				"code": "arbcom-en",
+				"private": ""
+			},
+			{
+				"url": "https://arbcom-fi.wikipedia.org",
+				"dbname": "arbcom_fiwiki",
+				"code": "arbcom-fi",
+				"private": ""
+			},
+			{
+				"url": "https://arbcom-nl.wikipedia.org",
+				"dbname": "arbcom_nlwiki",
+				"code": "arbcom-nl",
+				"private": ""
+			},
+			{
+				"url": "https://auditcom.wikimedia.org",
+				"dbname": "auditcomwiki",
+				"code": "auditcom",
+				"private": ""
+			},
+			{
+				"url": "http://bd.wikimedia.org",
+				"dbname": "bdwikimedia",
+				"code": "bdwikimedia"
+			},
+			{
+				"url": "http://be.wikimedia.org",
+				"dbname": "bewikimedia",
+				"code": "bewikimedia"
+			},
+			{
+				"url": "http://beta.wikiversity.org",
+				"dbname": "betawikiversity",
+				"code": "betawikiversity"
+			},
+			{
+				"url": "https://board.wikimedia.org",
+				"dbname": "boardwiki",
+				"code": "board",
+				"private": ""
+			},
+			{
+				"url": "https://boardgovcom.wikimedia.org",
+				"dbname": "boardgovcomwiki",
+				"code": "boardgovcom",
+				"private": ""
+			},
+			{
+				"url": "http://br.wikimedia.org",
+				"dbname": "brwikimedia",
+				"code": "brwikimedia"
+			},
+			{
+				"url": "http://ca.wikimedia.org",
+				"dbname": "cawikimedia",
+				"code": "cawikimedia"
+			},
+			{
+				"url": "https://chair.wikimedia.org",
+				"dbname": "chairwiki",
+				"code": "chair",
+				"private": ""
+			},
+			{
+				"url": "https://chapcom.wikimedia.org",
+				"dbname": "chapcomwiki",
+				"code": "chapcom",
+				"private": ""
+			},
+			{
+				"url": "https://checkuser.wikimedia.org",
+				"dbname": "checkuserwiki",
+				"code": "checkuser",
+				"private": ""
+			},
+			{
+				"url": "http://co.wikimedia.org",
+				"dbname": "cowikimedia",
+				"code": "cowikimedia"
+			},
+			{
+				"url": "https://collab.wikimedia.org",
+				"dbname": "collabwiki",
+				"code": "collab",
+				"private": ""
+			},
+			{
+				"url": "http://commons.wikimedia.org",
+				"dbname": "commonswiki",
+				"code": "commons"
+			},
+			{
+				"url": "http://dk.wikimedia.org",
+				"dbname": "dkwikimedia",
+				"code": "dkwikimedia"
+			},
+			{
+				"url": "https://donate.wikimedia.org",
+				"dbname": "donatewiki",
+				"code": "donate",
+				"fishbowl": ""
+			},
+			{
+				"url": "http://et.wikimedia.org",
+				"dbname": "etwikimedia",
+				"code": "etwikimedia"
+			},
+			{
+				"url": "https://exec.wikimedia.org",
+				"dbname": "execwiki",
+				"code": "exec",
+				"private": ""
+			},
+			{
+				"url": "https://fdc.wikimedia.org",
+				"dbname": "fdcwiki",
+				"code": "fdc",
+				"private": ""
+			},
+			{
+				"url": "http://fi.wikimedia.org",
+				"dbname": "fiwikimedia",
+				"code": "fiwikimedia"
+			},
+			{
+				"url": "http://wikimediafoundation.org",
+				"dbname": "foundationwiki",
+				"code": "foundation",
+				"fishbowl": ""
+			},
+			{
+				"url": "https://grants.wikimedia.org",
+				"dbname": "grantswiki",
+				"code": "grants",
+				"private": ""
+			},
+			{
+				"url": "https://iegcom.wikimedia.org",
+				"dbname": "iegcomwiki",
+				"code": "iegcom",
+				"private": ""
+			},
+			{
+				"url": "http://il.wikimedia.org",
+				"dbname": "ilwikimedia",
+				"code": "ilwikimedia",
+				"private": ""
+			},
+			{
+				"url": "http://incubator.wikimedia.org",
+				"dbname": "incubatorwiki",
+				"code": "incubator"
+			},
+			{
+				"url": "https://internal.wikimedia.org",
+				"dbname": "internalwiki",
+				"code": "internal",
+				"private": ""
+			},
+			{
+				"url": "https://wikitech.wikimedia.org",
+				"dbname": "labswiki",
+				"code": "labs",
+				"fishbowl": ""
+			},
+			{
+				"url": "https://legalteam.wikimedia.org",
+				"dbname": "legalteamwiki",
+				"code": "legalteam",
+				"private": ""
+			},
+			{
+				"url": "http://login.wikimedia.org",
+				"dbname": "loginwiki",
+				"code": "login"
+			},
+			{
+				"url": "http://www.mediawiki.org",
+				"dbname": "mediawikiwiki",
+				"code": "mediawiki"
+			},
+			{
+				"url": "http://meta.wikimedia.org",
+				"dbname": "metawiki",
+				"code": "meta"
+			},
+			{
+				"url": "http://mk.wikimedia.org",
+				"dbname": "mkwikimedia",
+				"code": "mkwikimedia"
+			},
+			{
+				"url": "https://movementroles.wikimedia.org",
+				"dbname": "movementroleswiki",
+				"code": "movementroles",
+				"private": ""
+			},
+			{
+				"url": "http://mx.wikimedia.org",
+				"dbname": "mxwikimedia",
+				"code": "mxwikimedia"
+			},
+			{
+				"url": "http://nl.wikimedia.org",
+				"dbname": "nlwikimedia",
+				"code": "nlwikimedia"
+			},
+			{
+				"url": "http://no.wikimedia.org",
+				"dbname": "nowikimedia",
+				"code": "nowikimedia"
+			},
+			{
+				"url": "http://noboard-chapters.wikimedia.org",
+				"dbname": "noboard_chapterswikimedia",
+				"code": "noboard-chapterswikimedia",
+				"private": ""
+			},
+			{
+				"url": "http://nostalgia.wikipedia.org",
+				"dbname": "nostalgiawiki",
+				"code": "nostalgia",
+				"fishbowl": ""
+			},
+			{
+				"url": "http://nyc.wikimedia.org",
+				"dbname": "nycwikimedia",
+				"code": "nycwikimedia"
+			},
+			{
+				"url": "http://nz.wikimedia.org",
+				"dbname": "nzwikimedia",
+				"code": "nzwikimedia",
+				"closed": ""
+			},
+			{
+				"url": "https://office.wikimedia.org",
+				"dbname": "officewiki",
+				"code": "office",
+				"private": ""
+			},
+			{
+				"url": "https://ombudsmen.wikimedia.org",
+				"dbname": "ombudsmenwiki",
+				"code": "ombudsmen",
+				"private": ""
+			},
+			{
+				"url": "https://otrs-wiki.wikimedia.org",
+				"dbname": "otrs_wikiwiki",
+				"code": "otrs-wiki",
+				"private": ""
+			},
+			{
+				"url": "http://outreach.wikimedia.org",
+				"dbname": "outreachwiki",
+				"code": "outreach"
+			},
+			{
+				"url": "http://pa-us.wikimedia.org",
+				"dbname": "pa_uswikimedia",
+				"code": "pa-uswikimedia",
+				"closed": ""
+			},
+			{
+				"url": "http://pl.wikimedia.org",
+				"dbname": "plwikimedia",
+				"code": "plwikimedia"
+			},
+			{
+				"url": "http://quality.wikimedia.org",
+				"dbname": "qualitywiki",
+				"code": "quality",
+				"closed": ""
+			},
+			{
+				"url": "http://rs.wikimedia.org",
+				"dbname": "rswikimedia",
+				"code": "rswikimedia",
+				"fishbowl": ""
+			},
+			{
+				"url": "https://ru.wikimedia.org",
+				"dbname": "ruwikimedia",
+				"code": "ruwikimedia"
+			},
+			{
+				"url": "http://se.wikimedia.org",
+				"dbname": "sewikimedia",
+				"code": "sewikimedia"
+			},
+			{
+				"url": "https://searchcom.wikimedia.org",
+				"dbname": "searchcomwiki",
+				"code": "searchcom",
+				"private": ""
+			},
+			{
+				"url": "http://wikisource.org",
+				"dbname": "sourceswiki",
+				"code": "sources"
+			},
+			{
+				"url": "https://spcom.wikimedia.org",
+				"dbname": "spcomwiki",
+				"code": "spcom",
+				"private": ""
+			},
+			{
+				"url": "http://species.wikimedia.org",
+				"dbname": "specieswiki",
+				"code": "species"
+			},
+			{
+				"url": "https://steward.wikimedia.org",
+				"dbname": "stewardwiki",
+				"code": "steward",
+				"private": ""
+			},
+			{
+				"url": "http://strategy.wikimedia.org",
+				"dbname": "strategywiki",
+				"code": "strategy",
+				"closed": ""
+			},
+			{
+				"url": "http://ten.wikipedia.org",
+				"dbname": "tenwiki",
+				"code": "ten",
+				"closed": ""
+			},
+			{
+				"url": "http://test.wikipedia.org",
+				"dbname": "testwiki",
+				"code": "test"
+			},
+			{
+				"url": "http://test2.wikipedia.org",
+				"dbname": "test2wiki",
+				"code": "test2"
+			},
+			{
+				"url": "http://test.wikidata.org",
+				"dbname": "testwikidatawiki",
+				"code": "testwikidata"
+			},
+			{
+				"url": "http://tr.wikimedia.org",
+				"dbname": "trwikimedia",
+				"code": "trwikimedia"
+			},
+			{
+				"url": "https://transitionteam.wikimedia.org",
+				"dbname": "transitionteamwiki",
+				"code": "transitionteam",
+				"private": ""
+			},
+			{
+				"url": "http://ua.wikimedia.org",
+				"dbname": "uawikimedia",
+				"code": "uawikimedia"
+			},
+			{
+				"url": "http://uk.wikimedia.org",
+				"dbname": "ukwikimedia",
+				"code": "ukwikimedia",
+				"closed": ""
+			},
+			{
+				"url": "http://usability.wikimedia.org",
+				"dbname": "usabilitywiki",
+				"code": "usability",
+				"closed": ""
+			},
+			{
+				"url": "https://vote.wikimedia.org",
+				"dbname": "votewiki",
+				"code": "vote",
+				"fishbowl": ""
+			},
+			{
+				"url": "https://wg-en.wikipedia.org",
+				"dbname": "wg_enwiki",
+				"code": "wg-en",
+				"private": ""
+			},
+			{
+				"url": "http://www.wikidata.org",
+				"dbname": "wikidatawiki",
+				"code": "wikidata"
+			},
+			{
+				"url": "http://wikimania2005.wikimedia.org",
+				"dbname": "wikimania2005wiki",
+				"code": "wikimania2005",
+				"closed": ""
+			},
+			{
+				"url": "http://wikimania2006.wikimedia.org",
+				"dbname": "wikimania2006wiki",
+				"code": "wikimania2006",
+				"closed": ""
+			},
+			{
+				"url": "http://wikimania2007.wikimedia.org",
+				"dbname": "wikimania2007wiki",
+				"code": "wikimania2007",
+				"closed": ""
+			},
+			{
+				"url": "http://wikimania2008.wikimedia.org",
+				"dbname": "wikimania2008wiki",
+				"code": "wikimania2008",
+				"closed": ""
+			},
+			{
+				"url": "http://wikimania2009.wikimedia.org",
+				"dbname": "wikimania2009wiki",
+				"code": "wikimania2009",
+				"closed": ""
+			},
+			{
+				"url": "http://wikimania2010.wikimedia.org",
+				"dbname": "wikimania2010wiki",
+				"code": "wikimania2010",
+				"closed": ""
+			},
+			{
+				"url": "http://wikimania2011.wikimedia.org",
+				"dbname": "wikimania2011wiki",
+				"code": "wikimania2011",
+				"closed": ""
+			},
+			{
+				"url": "http://wikimania2012.wikimedia.org",
+				"dbname": "wikimania2012wiki",
+				"code": "wikimania2012",
+				"closed": ""
+			},
+			{
+				"url": "http://wikimania2013.wikimedia.org",
+				"dbname": "wikimania2013wiki",
+				"code": "wikimania2013",
+				"closed": ""
+			},
+			{
+				"url": "http://wikimania2014.wikimedia.org",
+				"dbname": "wikimania2014wiki",
+				"code": "wikimania2014"
+			},
+			{
+				"url": "http://wikimania2015.wikimedia.org",
+				"dbname": "wikimania2015wiki",
+				"code": "wikimania2015"
+			},
+			{
+				"url": "http://wikimania2016.wikimedia.org",
+				"dbname": "wikimania2016wiki",
+				"code": "wikimania2016"
+			},
+			{
+				"url": "https://wikimaniateam.wikimedia.org",
+				"dbname": "wikimaniateamwiki",
+				"code": "wikimaniateam",
+				"private": ""
+			},
+			{
+				"url": "https://zero.wikimedia.org",
+				"dbname": "zerowiki",
+				"code": "zero",
+				"private": ""
+			}
+		]
+	}
+};
+module.exports = sitematrix;


### PR DESCRIPTION
This lets you specify eg enwiktionary as the parameter which is currently called lang