### PR TITLE
removed unwanted "{{Gallery" and "{{Taxobox" from text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.git
+

--- a/index.js
+++ b/index.js
@@ -230,6 +230,9 @@ var wtf_wikipedia=(function(){
         line=line.replace(/\([^a-z]{0,8}\)/,'')
         line=helpers.trim_whitespace(line)
 
+        // put new lines back in
+        line=line+"\n";
+
         return line
     }
 
@@ -436,9 +439,14 @@ var wtf_wikipedia=(function(){
         //remove some nonsense wp lines
         //
         //ignore list
+        if(part.match(/^[#:;\|]/)){
+            return
+        }
+/*
         if(part.match(/^[\*#:;\|]/)){
             return
         }
+*/
         //ignore only-punctuation
         if(!part.match(/[a-z0-9]/i)){
             return

--- a/index.js
+++ b/index.js
@@ -354,7 +354,7 @@ var wtf_wikipedia=(function(){
             if(!table[table.length-1]){
               table[table.length-1]=[]
             }
-            var want= (str.match(/\|(.*)/)||[])[1]||''
+            var want= (str.match(/\|(.*)/)||[])[1]|''
             want= helpers.trim_whitespace(want)||''
             //handle the || shorthand..
             if(want.match(/[!\|]{2}/)){
@@ -408,7 +408,7 @@ var wtf_wikipedia=(function(){
         if(s.match(infobox_reg, "ig") && Object.keys(infobox).length==0){
           infobox= parse_infobox(s)
         }
-        if(s.match(/\{\{(cite|infobox|Inligtingskas|sister|geographic|navboxes|listen|historical|citeweb|citenews|lien|clima|cita|Internetquelle|article|weather)[ \|:\n]/i)){
+        if(s.match(/\{\{(Gallery|Taxobox|cite|infobox|Inligtingskas|sister|geographic|navboxes|listen|historical|citeweb|citenews|lien|clima|cita|Internetquelle|article|weather)[ \|:\n]/i)){
           wiki=wiki.replace(s,'')
         }
       })


### PR DESCRIPTION
After pull, eg, from http://en.wikipedia.org/wiki/Leopard, ugly "{{Gallery" and "{{Taxobox" remained in text. This takes care of that problem.