### PR TITLE
Add infobox template parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,6 +182,18 @@ var wtf_wikipedia=(function(){
         return obj
     }
 
+    function parse_infobox_template(str){
+      var template= ''
+      if(str){
+        var infobox_template_reg=new RegExp("\{\{(?:"+i18n.infoboxes.join("|")+")\\s*(.*)", "i")
+        var matches= str.match(infobox_template_reg)
+        if (matches && matches.length > 1) {
+          template= matches[1]
+        }
+      }
+      return template
+    }
+
     function preprocess(wiki){
       //the dump requires us to unescape xml
       // unescape = [['>', '&gt;'],[ '<', '&lt;'],[ "'", '&apos;'],[ '"', '&quot;'],[ '&', '&amp;']]
@@ -391,6 +403,7 @@ var wtf_wikipedia=(function(){
 
     var main=function(wiki){
       var infobox={}
+      var infobox_template=''
       var images=[]
       var categories=[];
       var tables=[]
@@ -427,6 +440,7 @@ var wtf_wikipedia=(function(){
       matches.forEach(function(s){
         if(s.match(infobox_reg, "ig") && Object.keys(infobox).length==0){
           infobox= parse_infobox(s)
+          infobox_template= parse_infobox_template(s)
         }
         if(s.match(/\{\{(Gallery|Taxobox|cite|infobox|Inligtingskas|sister|geographic|navboxes|listen|historical|citeweb|citenews|lien|clima|cita|Internetquelle|article|weather)[ \|:\n]/i)){
           wiki=wiki.replace(s,'')
@@ -533,6 +547,7 @@ var wtf_wikipedia=(function(){
         categories:cats,
         images:images,
         infobox:infobox,
+        infobox_template:infobox_template,
         tables:tables,
         translations:translations,
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wtf_wikipedia",
   "description": "parse wikiscript into json",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "author": "Spencer Kelly <spencermountain@gmail.com> (http://spencermounta.in)",
   "repository": {
     "type": "git",

--- a/tests/test.js
+++ b/tests/test.js
@@ -10,36 +10,38 @@ var fetch=function(file){
 
 Tests['royal_cinema'] = function(test) {
    var data=parser(fetch("royal_cinema"))
-   test.ok( data.infobox.opened.text, "INFOBOX");
-   test.ok( data.text.Intro.length, 5);
-   test.ok( data.categories.length, 4);
+   test.equal(data.infobox.opened.text, '1939');
    test.equal(data.infobox_template, 'venue')
+   test.equal(data.text.Intro.length, 10);
+   test.equal(data.categories.length, 4);
    test.done();
 };
 
 Tests['toronto_star'] = function(test) {
    var data=parser(fetch("toronto_star"))
-   test.ok( data.infobox.publisher.text, 'John D. Cruickshank');
-   test.ok( data.text.History.length, 7);
-   test.ok( data.categories.length, 6);
+   test.equal(data.infobox.publisher.text, 'John D. Cruickshank');
    test.equal(data.infobox_template, 'newspaper')
+   test.equal(data.text.History.length, 21);
+   test.equal(data.categories.length, 6);
    test.done();
 };
 
 Tests['jodie_emery'] = function(test) {
   var data=parser(fetch("jodie_emery"))
-  test.ok(data.infobox.nationality.text, 'Canadian')
+  test.equal(data.infobox.nationality.text, 'Canadian')
   test.equal(data.infobox_template, 'person')
   test.ok(data.text.Intro.length>=1)
   test.ok(data.text['Political career'].length>=5)
-  test.ok(data.categories.length, 8)
-  test.ok(data.images.length, 1)
+  test.equal(data.categories.length, 8)
+  test.equal(data.images.length, 1)
   test.done();
 };
 
 Tests['redirect'] = function(test) {
   var data=parser(fetch("redirect"))
-  test.ok(data.redirect, 'Toronto')
+  test.equal(data.type, 'redirect')
+  test.equal(data.redirect, 'Toronto')
+  test.ok(data.infobox == null)
   test.ok(data.infobox_template == null)
   test.done();
 };

--- a/tests/test.js
+++ b/tests/test.js
@@ -13,6 +13,7 @@ Tests['royal_cinema'] = function(test) {
    test.ok( data.infobox.opened.text, "INFOBOX");
    test.ok( data.text.Intro.length, 5);
    test.ok( data.categories.length, 4);
+   test.equal(data.infobox_template, 'venue')
    test.done();
 };
 
@@ -21,12 +22,14 @@ Tests['toronto_star'] = function(test) {
    test.ok( data.infobox.publisher.text, 'John D. Cruickshank');
    test.ok( data.text.History.length, 7);
    test.ok( data.categories.length, 6);
+   test.equal(data.infobox_template, 'newspaper')
    test.done();
 };
 
 Tests['jodie_emery'] = function(test) {
   var data=parser(fetch("jodie_emery"))
   test.ok(data.infobox.nationality.text, 'Canadian')
+  test.equal(data.infobox_template, 'person')
   test.ok(data.text.Intro.length>=1)
   test.ok(data.text['Political career'].length>=5)
   test.ok(data.categories.length, 8)
@@ -37,5 +40,6 @@ Tests['jodie_emery'] = function(test) {
 Tests['redirect'] = function(test) {
   var data=parser(fetch("redirect"))
   test.ok(data.redirect, 'Toronto')
+  test.ok(data.infobox_template == null)
   test.done();
 };


### PR DESCRIPTION
@spencermountain Hi! Having access to the [infobox template type](https://en.wikipedia.org/wiki/Template%3AInfobox) in wtf_wikipedia's parsed response is necessary for the project I'm working on, and this PR adds it. I also fixed the tests while I was at it; there were a number of places where it should've been `test.equal()` instead of `test.ok()`.