### PR TITLE
Corrected location of the main file

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git://github.com/spencermountain/wtf_wikipedia.git"
   },
-  "main": "index.js",
+  "main": "src/index.js",
   "engines": [
     "node >= 0.4.1"
   ],


### PR DESCRIPTION
I noticed this when wtf_wikipedia wouldn't work at all when I did `require("wtf_wikipedia")`