### PR TITLE
Fix to integer parsing in infobox

### DIFF
--- a/src/parse/parse_infobox.js
+++ b/src/parse/parse_infobox.js
@@ -51,7 +51,7 @@ function parse_infobox(str) {
                 obj[key] = parse_line(value);
                 //turn number strings into integers
                 if (obj[key].text && obj[key].text.match(/^[0-9,]*$/)) {
-                    obj[key].text = obj[key].text.replace(/,/g);
+                    obj[key].text = obj[key].text.replace(/,/, '');
                     obj[key].text = parseInt(obj[key].text, 10);
                 }
             }


### PR DESCRIPTION
Fixed issue where integers with commas in them were getting truncated because .replace(/,/g) would turn "12,100" into "12undefined100" and parseInt would then spit out 12.