### PR TITLE
Hit callback with null for searches that don't lead to anything useful

### DIFF
--- a/src/lib/fetch_text.js
+++ b/src/lib/fetch_text.js
@@ -40,6 +40,8 @@ var fetch = function(page_identifier, lang_or_wikiid, cb) {
             return;
           }
           cb(text);
+        } else {
+          cb(null);
         }
       }
     });


### PR DESCRIPTION
When doing a search like

fetch('HUYF%EHJHDAS#', 'en', function(r) { // 'afwiki'
  console.log(JSON.stringify(r, null, 2));
});

the callback will never be called because in fetch_text.js, the eval page && page.revisions && page.revisions[0] will not be true.

the code should then callback with null so that apps using this module can act accordinglya



https://github.com/moustachedelait/wtf_wikipedia/compare/master...moustachedelait:callback_bad_results?expand=1