### PR TITLE
use Travis CI for continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,18 @@ sudo: false
 language: node_js
 
 node_js:
-  - "4"
+  - stable
+  - 7
+  - 6
+  - 5
+  - 4
 
 cache:
   directories:
     - node_modules
 
-before_install: npm install -g grunt-cli
-
 install: npm install
 
-script: npm run test
+script:
+  - npm run test
+  - npm run build


### PR DESCRIPTION
having a CI allows maintainers to quickly tell if PRs are breaking tests. also, services like [greenkeeper](https://greenkeeper.io) make it easier to keep up with outdated dependencies! please [enable Travis](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/) along with this PR.

furthermore, I'd add a [build status badge](http://shields.io) that indicates the well-being of a lib to new people.