### PR TITLE
Catch error: Cannot read property 'pages' of undefined

### DIFF
--- a/src/lib/fetch_text.js
+++ b/src/lib/fetch_text.js
@@ -26,21 +26,27 @@ const fetch = function(page_identifier, lang_or_wikiid, cb) {
       cb(null);
       return;
     }
-    var pages = res.body.query.pages || {};
-    var id = Object.keys(pages)[0];
-    if (id) {
-      var page = pages[id];
-      if (page && page.revisions && page.revisions[0]) {
-        var text = page.revisions[0]['*'];
-        if (redirects.is_redirect(text)) {
-          var result = redirects.parse_redirect(text);
-          fetch(result.redirect, lang_or_wikiid, cb); //recursive
-          return;
+    try {
+      var pages = res.body.query.pages || {};
+      var id = Object.keys(pages)[0];
+      if (id) {
+        var page = pages[id];
+        if (page && page.revisions && page.revisions[0]) {
+          var text = page.revisions[0]['*'];
+          if (redirects.is_redirect(text)) {
+            var result = redirects.parse_redirect(text);
+            fetch(result.redirect, lang_or_wikiid, cb); //recursive
+            return;
+          }
+          cb(text);
+        } else {
+          cb(null);
         }
-        cb(text);
-      } else {
-        cb(null);
       }
+    }
+    catch (e) {
+      // Sometimes this breaks
+      cb(e);
     }
   });
 };


### PR DESCRIPTION
We saw this error when looking up something in our production app:

```
Cannot read property 'pages' of undefined
TypeError: Cannot read property 'pages' of undefined
    at /var/apps/indigo/ic-webapp/node_modules/wtf_wikipedia/src/lib/fetch_text.js:31:33
    at Request.callback (/var/apps/indigo/ic-webapp/node_modules/superagent/lib/node/index.js:619:12)
    at /var/apps/indigo/ic-webapp/node_modules/superagent/lib/node/index.js:795:18
    at Stream.<anonymous> (/var/apps/indigo/ic-webapp/node_modules/superagent/lib/node/parsers/json.js:16:7)
    at emitNone (events.js:86:13)
    at Stream.emit (events.js:185:7)
    at Unzip.<anonymous> (/var/apps/indigo/ic-webapp/node_modules/superagent/lib/node/utils.js:112:12)
    at emitNone (events.js:91:20)
    at Unzip.emit (events.js:185:7)
```

Unfortunately because it's in a callback we can't catch it, so we had to patch it.