### PR TITLE
Support multiple infoboxes

### DIFF
--- a/src/parse/recursive/index.js
+++ b/src/parse/recursive/index.js
@@ -14,11 +14,13 @@ const noWrap_reg = /^\{\{nowrap\|(.*?)\}\}$/;
 //reduce the scary recursive situations
 const parse_recursive = function(r, wiki) {
   //remove {{template {{}} }} recursions
+  r.infoboxes=[];
   let matches = find_recursive('{', '}', wiki);
   matches.forEach(function(s) {
-    if (s.match(infobox_reg, 'ig') && Object.keys(r.infobox).length === 0) {
-      r.infobox = parse_infobox(s);
-      r.infobox_template = parse_infobox_template(s);
+    if (s.match(infobox_reg, 'ig')) {
+      var infobox = parse_infobox(s);
+      infobox.template = parse_infobox_template(s);
+      r.infoboxes.push(infobox);
     }
     if (s.match(infobox_reg)) {
       wiki = wiki.replace(s, '');


### PR DESCRIPTION
Some MediaWikis contain two or more infoboxes. With the current implementation, only the first of those is parsed and the others discarded. All I did was move the infoboxes into an array, and put the template onto the infobox object itself rather than it's own key.

And example of a MediaWiki with multiple infoboxes is http://oldschoolrunescape.wikia.com/wiki/Amulet_of_magic_(t)?action=raw