### PR TITLE
Check revisions response is defined before using

### DIFF
--- a/src/lib/fetch_text.js
+++ b/src/lib/fetch_text.js
@@ -26,7 +26,7 @@ const fetch = function(page_identifier, lang_or_wikiid, cb) {
       cb(null);
       return;
     }
-    var pages = res.body.query.pages || {};
+    var pages = (res && res.body && res.body.query) ? res.body.query.pages : {};
     var id = Object.keys(pages)[0];
     if (id) {
       var page = pages[id];


### PR DESCRIPTION
Just a check that the revisions request response has a body and query field before attempting to access 'pages' field to prevent `Uncaught Exception:  Cannot read property 'pages' of undefined` errors.