### PR TITLE
Interlanguage links interfere with wikibook/cookbook links

### DIFF
--- a/src/parse/section/image/index.js
+++ b/src/parse/section/image/index.js
@@ -1,4 +1,5 @@
 const i18n = require('../../../data/i18n');
+const languages = require('../../../data/languages');
 const find_recursive = require('../../../lib/recursive_match');
 const parse_image = require('./image');
 const fileRegex = new RegExp('(' + i18n.images.concat(i18n.files).join('|') + '):.*?[\\|\\]]', 'i');
@@ -19,7 +20,7 @@ const parseImages = function(r, wiki) {
     if (s.match(/\[\[([a-z]+):(.*?)\]\]/i) !== null) {
       let site = (s.match(/\[\[([a-z]+):/i) || [])[1] || '';
       site = site.toLowerCase();
-      if (site && i18n.dictionary[site] === undefined) {
+      if (site && i18n.dictionary[site] === undefined && languages[site] != undefined) {
         r.interwiki = r.interwiki || {};
         r.interwiki[site] = (s.match(/\[\[([a-z]+):(.*?)\]\]/i) || [])[2];
         wiki = wiki.replace(s, '');


### PR DESCRIPTION
links that look like [[Cookbook:Casserole|casserole]] are identified as interlanguage links and removed which also removes the word casserole from the text.