### PR TITLE
Fix coordinate parsing

### DIFF
--- a/src/lib/convertGeo.js
+++ b/src/lib/convertGeo.js
@@ -9,7 +9,7 @@ function parseDms(arr) {
   var degrees = Number(arr[0] || 0);
   var minutes = Number(arr[1] || 0);
   var seconds = Number(arr[2] || 0);
-  if (typeof hemisphere !== 'string' || !degrees) {
+  if (typeof hemisphere !== 'string' || isNaN(degrees)) {
     return null;
   }
   var sign = 1;

--- a/src/parse/preProcess/coordinates.js
+++ b/src/parse/preProcess/coordinates.js
@@ -28,7 +28,7 @@ const parseCoord = function(str) {
   //turn numbers into numbers, normalize N/s
   let nums = [];
   for(let i = 0; i < arr.length; i += 1) {
-    let s = arr[i];
+    let s = arr[i].trim();
     //make it a number
     let num = parseFloat(s);
     if (num || num === 0) {

--- a/tests/coord.test.js
+++ b/tests/coord.test.js
@@ -18,6 +18,11 @@ test('coord formats', t => {
   t.equal(obj.lat, 51.5, 'fmt-2-with-zero-lat');
   t.equal(obj.lon, -0.11667, 'fmt-2-with-zero-lon');
 
+  str = `hello {{coord|9|26|44|S|160|01|13|E |display=title}} world`;
+  obj = wtf.parse(str).coordinates[0];
+  t.equal(obj.lat, -9.44556, 'fmt-2-with-space-lat');
+  t.equal(obj.lon, 160.02028, 'fmt-2-with-space-lon');
+
   //minutes/seconds
   str = `hello {{Coord|57|18|22|N|4|27|32|W|display=title}} world`;
   obj = wtf.parse(str).coordinates[0];

--- a/tests/coord.test.js
+++ b/tests/coord.test.js
@@ -13,6 +13,11 @@ test('coord formats', t => {
   t.equal(obj.lat, 44.112, 'fmt-2-lat');
   t.equal(obj.lon, -87.913, 'fmt-2-lon');
 
+  str = `hello {{Coord|51|30|N|0|7|W|type:city}} world`;
+  obj = wtf.parse(str).coordinates[0];
+  t.equal(obj.lat, 51.5, 'fmt-2-with-zero-lat');
+  t.equal(obj.lon, -0.11667, 'fmt-2-with-zero-lon');
+
   //minutes/seconds
   str = `hello {{Coord|57|18|22|N|4|27|32|W|display=title}} world`;
   obj = wtf.parse(str).coordinates[0];


### PR DESCRIPTION
The [United Kingdom](https://en.wikipedia.org/wiki/United_Kingdom) coordinates `{{Coord|51|30|N|0|7|W|type:city}}` are parsed as `{lat: 0, lon: 7}` instead of `{lat: 51.5, lon: -0.11667}` because of `!degrees` check.

The [Guadalcanal Campaign](https://en.wikipedia.org/wiki/Guadalcanal_Campaign) coordinates `{{coord|9|26|44|S|160|01|13|E |format=dms |region:SB_type:event |display=title}}` are parsed as `{lat: -9.44556, lon: null}` instead of `{lat: -9.44556, lon: 160.02028}` because the space in `|E |` is not trimmed.
