### PR TITLE
Increase maximum <ref> length

### DIFF
--- a/src/parse/preProcess/kill_xml.js
+++ b/src/parse/preProcess/kill_xml.js
@@ -36,7 +36,7 @@ const kill_xml = function(wiki, r) {
   // <ref name=""/>
   wiki = wiki.replace(/ ?<ref [^>]{0,200}?\/> ?/gi, ' ');
   // <ref name=""></ref>
-  wiki = wiki.replace(/ ?<ref [^>]{0,200}?>([\s\S]{0,500}?)<\/ref> ?/gi, function(a, tmpl) {
+  wiki = wiki.replace(/ ?<ref [^>]{0,200}?>([\s\S]{0,1000}?)<\/ref> ?/gi, function(a, tmpl) {
     if (hasCitation(tmpl)) {
       wiki = parseCitation(tmpl, wiki, r);
     } else {


### PR DESCRIPTION
Try `wikipedia New York City | grep '<ref'`. There are 11 refs left, for instance:

```
"text": "The city's fast pace<ref name=FastPaceNYC1> defines the term ."
```

instead of

```
"text": "The city's fast pace defines the term New York minute.",
```

I’m not sure if there should be a limit at all, but for now I simply tried to double it.