### PR TITLE
fix for special namespaces like "cookbook" which get their their text dumped for looking like interwiki links

### DIFF
--- a/bin/plaintext.js
+++ b/bin/plaintext.js
@@ -9,7 +9,12 @@ if (!title) {
 }
 title = title.charAt(0).toUpperCase() + title.slice(1);
 //fetch this topic's wikipedia page
-wtf.from_api(title, 'en', function (script) {
-  var data = wtf.plaintext(script);
+wtf.from_api(title, 'en', function (script, page_identifier, lang_or_wikiid) {
+  var o = {
+    page_identifier:page_identifier,
+    lang_or_wikiid:lang_or_wikiid
+  };
+
+  var data = wtf.plaintext(script, o);
   console.log(data);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ const from_api = function(page_identifier, lang_or_wikiid, cb) {
 };
 
 //turn wiki-markup into a nicely-formatted text
-const plaintext = function(str) {
+const plaintext = function(str, options) {
   let data = parse(str, options) || {};
   data.sections = data.sections || [];
   let arr = data.sections.map(d => {

--- a/src/index.js
+++ b/src/index.js
@@ -24,8 +24,9 @@ const from_api = function(page_identifier, lang_or_wikiid, cb) {
 };
 
 //turn wiki-markup into a nicely-formatted text
-const plaintext = function(str, options) {
-  let data = parse(str, options) || {};
+const plaintext = function(str, optionsP) {
+  optionsP = optionsP === undefined ? options : optionsP;
+  let data = parse(str, optionsP) || {};
   data.sections = data.sections || [];
   let arr = data.sections.map(d => {
     return d.sentences.map(a => a.text).join(' ');

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -48,7 +48,7 @@ const main = function(wiki, options) {
   //pull-out [[category:whatevers]]
   wiki = parse.categories(r, wiki);
   //parse all the headings, and their texts/sentences
-  r.sections = parse.section(r, wiki) || [];
+  r.sections = parse.section(r, wiki, options) || [];
 
   r = postProcess(r);
 

--- a/src/parse/section/image/index.js
+++ b/src/parse/section/image/index.js
@@ -20,10 +20,12 @@ const parseImages = function(r, wiki) {
     if (s.match(/\[\[([a-z]+):(.*?)\]\]/i) !== null) {
       let site = (s.match(/\[\[([a-z]+):/i) || [])[1] || '';
       site = site.toLowerCase();
-      if (site && i18n.dictionary[site] === undefined && languages[site] != undefined) {
+      if (site && i18n.dictionary[site] === undefined) {
         r.interwiki = r.interwiki || {};
         r.interwiki[site] = (s.match(/\[\[([a-z]+):(.*?)\]\]/i) || [])[2];
-        wiki = wiki.replace(s, '');
+        if (languages[site] != undefined) {
+          wiki = wiki.replace(s, '');
+        }
       }
     }
   });

--- a/src/parse/section/image/index.js
+++ b/src/parse/section/image/index.js
@@ -15,17 +15,18 @@ const parseImages = function(r, wiki) {
     }
   });
 
+  var namespaceList = r.page_identifier != undefined ? r.page_identifier.match(/^(.*?):.*$/) : [];
+  var namespace = namespaceList.length > 1 ? namespaceList[1].toLowerCase() : "";
+
   //third, wiktionary-style interlanguage links
   matches.forEach(function(s) {
     if (s.match(/\[\[([a-z]+):(.*?)\]\]/i) !== null) {
       let site = (s.match(/\[\[([a-z]+):/i) || [])[1] || '';
       site = site.toLowerCase();
-      if (site && i18n.dictionary[site] === undefined) {
+      if (site && i18n.dictionary[site] === undefined && site !== namespace) {
         r.interwiki = r.interwiki || {};
         r.interwiki[site] = (s.match(/\[\[([a-z]+):(.*?)\]\]/i) || [])[2];
-        if (languages[site] != undefined) {
-          wiki = wiki.replace(s, '');
-        }
+        wiki = wiki.replace(s, '');
       }
     }
   });

--- a/src/parse/section/image/index.js
+++ b/src/parse/section/image/index.js
@@ -1,10 +1,9 @@
 const i18n = require('../../../data/i18n');
-const languages = require('../../../data/languages');
 const find_recursive = require('../../../lib/recursive_match');
 const parse_image = require('./image');
 const fileRegex = new RegExp('(' + i18n.images.concat(i18n.files).join('|') + '):.*?[\\|\\]]', 'i');
 
-const parseImages = function(r, wiki) {
+const parseImages = function(r, wiki, options) {
   //second, remove [[file:...[[]] ]] recursions
   let matches = find_recursive('[', ']', wiki);
   matches.forEach(function(s) {
@@ -15,15 +14,12 @@ const parseImages = function(r, wiki) {
     }
   });
 
-  var namespaceList = r.page_identifier != undefined ? r.page_identifier.match(/^(.*?):.*$/) : [];
-  var namespace = namespaceList.length > 1 ? namespaceList[1].toLowerCase() : "";
-
   //third, wiktionary-style interlanguage links
   matches.forEach(function(s) {
     if (s.match(/\[\[([a-z]+):(.*?)\]\]/i) !== null) {
       let site = (s.match(/\[\[([a-z]+):/i) || [])[1] || '';
       site = site.toLowerCase();
-      if (site && i18n.dictionary[site] === undefined && site !== namespace) {
+      if (site && i18n.dictionary[site] === undefined && !(options.namespace !== undefined && options.namespace === site) ) {
         r.interwiki = r.interwiki || {};
         r.interwiki[site] = (s.match(/\[\[([a-z]+):(.*?)\]\]/i) || [])[2];
         wiki = wiki.replace(s, '');

--- a/src/parse/section/index.js
+++ b/src/parse/section/index.js
@@ -9,7 +9,7 @@ const parse = {
 };
 const section_reg = /[\n^](={1,5}[^=]{1,200}?={1,5})/g;
 
-const parseSection = function(section, wiki, r) {
+const parseSection = function(section, wiki, r, options) {
   // //parse the tables
   wiki = parse.table(section, wiki);
   // //parse the lists
@@ -17,14 +17,14 @@ const parseSection = function(section, wiki, r) {
   //supoprted things like {{main}}
   wiki = parse.template(section, wiki, r);
   // //parse+remove scary '[[ [[]] ]]' stuff
-  wiki = parse.image(section, wiki);
+  wiki = parse.image(section, wiki, options);
   //do each sentence
   wiki = parse.sentence(section, wiki);
   // section.wiki = wiki;
   return section;
 };
 
-const makeSections = function(r, wiki) {
+const makeSections = function(r, wiki, options) {
   let split = wiki.split(section_reg); //.filter(s => s);
   let sections = [];
   for (let i = 0; i < split.length; i += 2) {
@@ -35,7 +35,7 @@ const makeSections = function(r, wiki) {
       depth: null
     };
     section = parse.heading(section, title);
-    section = parseSection(section, txt, r);
+    section = parseSection(section, txt, r, options);
     sections.push(section);
   }
   return sections;


### PR DESCRIPTION
This should pass the test, but keeps extra text in cases where the link is not interlanguage.

If this makes the text too verbose, we can add an option such as verbose to toggle it?

Needed for cases where the name-space is cookbook or wikijunior.