### PR TITLE
Fix collapsible list case sensitivity and maximum length

### DIFF
--- a/src/parse/infobox/infobox.js
+++ b/src/parse/infobox/infobox.js
@@ -19,7 +19,7 @@ const parse_infobox = function(str) {
   let stringBuilder = [];
   let lastChar;
   //this collapsible list stuff is just a headache
-  str = str.replace(/\{\{Collapsible list[^}]{10,1000}\}\}/g, '');
+  str = str.replace(/\{\{Collapsible list[^}]{10,5000}\}\}/ig, '');
 
   const template = getTemplate(str); //get the infobox name
 


### PR DESCRIPTION
The United Kingdom `infoboxes` are full of trash because the collapsible list removal is case sensitive and limited to 1000 characters:

```
"name": {
  "text": "{{collapsible list"
},
"titlestyle": {
  "text": "background:transparent;line-height:normal;font-weight:normal;font-size:11px;"
},
"{{Infobox |subbox": {
  "text": "yes |bodystyle=font-size:76%;font-weight:normal;"
},
"rowclass1": {
  "text": "mergedrow |label1=Scots: |data1={{lang|sco|Unitit Kinrick o Great Breetain an Northren Ireland}}",
}
```
  