### PR TITLE
html_tidy and latex_tidy moved to tidy.js and handling of relative and inter-wiki links 

### DIFF
--- a/tests/html.test.js
+++ b/tests/html.test.js
@@ -1,37 +1,9 @@
 'use strict';
 var test = require('tape');
 var wtf = require('./lib');
+var tidy = require('./tidy');
 
-
-function html_tidy(pSource) {
-  /*
-  HTML: function is necessary for smart equal compare
-  due to equivalence in exported output
-  remove unnecessary characters that makes the test smarter against
-  syntactical layout change that still provide a correct output
-  */
-
-  // (1) Comments in Output
-  pSource = pSource.replace(/<!--[^>]*-->/g,"");
-
-  // (2) Newline
-  //pSource = pSource.replace(/\n/g,"");
-  // newline \n does not matter in HTML, but newlines are helpful
-  // for a more comprehensive output.
-  // Newlines can make the test fail, even if the generated code is OK.
-  // Therefore remove newlines in a tidy source
-
-  // (3) Blanks
-  // replace multiple blanks by one blank
-  pSource = pSource.replace(/\s/g," ");
-  pSource = pSource.replace(/ [ ]+/g," ");
-  // remove blanks before closing a tag with ">"
-  pSource = pSource.replace(/ >/g,">");
-
-  return pSource
-};
-
-// html_tidy defined in lib/index.js
+// tidy.html() defined in tidy.js
 
 test('basic-html', t => {
 
@@ -40,14 +12,14 @@ test('basic-html', t => {
   <p>that cat is <a class="link" href="./A">a</a> cool dude</p>
 </div>
 `;
-t.equal(html_tidy(have), html_tidy(want), 'link');
+t.equal(tidy.html(have), tidy.html(want), 'link');
 
   have = wtf.html('that cat is [[ab cd]] cool dude');
   want = `<div class="section">
   <p>that cat is <a class="link" href="./Ab_cd">ab cd</a> cool dude</p>
 </div>
 `;
-t.equal(html_tidy(have), html_tidy(want), 'link-blank');
+t.equal(tidy.html(have), tidy.html(want), 'link-blank');
 
   have = wtf.html('that is my image [[File:my_cat.png]]. Really cool');
   want = `<div class="section">
@@ -56,7 +28,7 @@ t.equal(html_tidy(have), html_tidy(want), 'link-blank');
   Really cool</p>
 </div>
 `;
-  t.equal(html_tidy(have), html_tidy(want), 'image-simple');
+  t.equal(tidy.html(have), tidy.html(want), 'image-simple');
 
   have = wtf.html('that is my image [[File:my_cat.png|center|700px|Image "Caption" for Cat]]. Really cool');
   want = `<div class="section">
@@ -66,14 +38,14 @@ t.equal(html_tidy(have), html_tidy(want), 'link-blank');
      </div>
      Really cool</p></div>
 `;
-  t.equal(html_tidy(have), html_tidy(want), 'image-center-size-caption');
+  t.equal(tidy.html(have), tidy.html(want), 'image-center-size-caption');
 
   have = wtf.html('that cat in [http://www.wikiversity.org other Wiki] is cool');
   want = `<div class="section">
  <p>that cat in <a class="link external" href="http://www.wikiversity.org" target="_blank">other Wiki</a> is cool</p>
 </div>
 `;
- t.equal(html_tidy(have), html_tidy(want), 'link-external');
+ t.equal(tidy.html(have), tidy.html(want), 'link-external');
 
  //1 tick
  have = wtf.html(`i 'think' so`);
@@ -81,7 +53,7 @@ t.equal(html_tidy(have), html_tidy(want), 'link-blank');
  <p>i 'think' so</p>
 </div>
 `;
- t.equal(html_tidy(have), html_tidy(want), 'one-tick');
+ t.equal(tidy.html(have), tidy.html(want), 'one-tick');
 
  //2 ticks
  have = wtf.html(`i ''think'' so`);
@@ -89,7 +61,7 @@ t.equal(html_tidy(have), html_tidy(want), 'link-blank');
  <p>i <i>think</i> so</p>
 </div>
 `;
- t.equal(html_tidy(have), html_tidy(want), 'italic');
+ t.equal(tidy.html(have), tidy.html(want), 'italic');
 
  //3 ticks
  have = wtf.html(`i '''think''' so`);
@@ -97,7 +69,7 @@ t.equal(html_tidy(have), html_tidy(want), 'link-blank');
  <p>i <b>think</b> so</p>
  </div>
  `;
- t.equal(html_tidy(have), html_tidy(want), 'bold');
+ t.equal(tidy.html(have), tidy.html(want), 'bold');
 
  //4 ticks
  have = wtf.html(`i ''''think'''' so`);
@@ -105,7 +77,7 @@ t.equal(html_tidy(have), html_tidy(want), 'link-blank');
  <p>i '<b>think</b>' so</p>
 </div>
 `;
- t.equal(html_tidy(have), html_tidy(want), 'four-tick');
+ t.equal(tidy.html(have), tidy.html(want), 'four-tick');
 
  //5 ticks
  have = wtf.html(`i '''''think''''' so`);
@@ -113,7 +85,7 @@ t.equal(html_tidy(have), html_tidy(want), 'link-blank');
  <p>i <b><i>think</i></b> so</p>
 </div>
 `;
- t.equal(html_tidy(have), html_tidy(want), 'five-tick');
+ t.equal(tidy.html(have), tidy.html(want), 'five-tick');
 
  //Nested itemize
  have = wtf.html(`Intro text
@@ -139,7 +111,7 @@ Final remarks`);
  Final remarks</p>
 </div>
 `;
- t.equal(html_tidy(have), html_tidy(want), 'nested-itemize');
+ t.equal(tidy.html(have), tidy.html(want), 'nested-itemize');
 
  //Nested enumerate in itemize
  have = wtf.html(`Intro text
@@ -166,7 +138,7 @@ Final remarks`);
  Final remarks</p>
 </div>
 `;
- t.equal(html_tidy(have), html_tidy(want), 'nested-itemize-enumerate');
+ t.equal(tidy.html(have), tidy.html(want), 'nested-itemize-enumerate');
 
 //-------------------
   t.end();

--- a/tests/latex.test.js
+++ b/tests/latex.test.js
@@ -1,113 +1,57 @@
 'use strict';
 var test = require('tape');
 var wtf = require('./lib');
+var tidy = require('./tidy');
 
-
-function latex_tidy(pSource) {
-  /*
-  LaTeX: function is necessary for smart equal compare
-  due to equivalence in exported latex output and
-  output changes that do not affect the correct layout of the code.
-  Removing of unnecessary characters that makes the test smarter against
-  syntactical layout change that still provide a correct output
-  */
-
-  // (1) Comments in Output
-  pSource = pSource.replace(/[\s]*%[^\n]\n/g,"");
-  //last line is a comment
-  pSource = pSource.replace(/[\s]*%[^\n]$/g,"");
-  // Comment is a line end starting with % and ending with a newline
-  // e.g.   latex test % my Comment
-  //        more latex text
-
-  // (2) Newline
-  pSource = pSource.replace(/\n[\s]*\n[\s\n]+/g,"\n\n");
-  /* more than two newlines \n (optional with spaces in between)
-  are equivalent to two newlines.
-  */
-
-  // (3) Blanks
-  // replace multiple blanks by one blank
-  pSource = pSource.replace(/\s[\s]+/g," ");
-
-  /*
-  Example for (2) and (3)
-  -------------------
-  ----SOURCE---------
-  -------------------
-  My   first
-  paragraph
-
-
-  The    second
-  paragraph    with
-  more     then     two   lines
-
-
-
-  the last paragraph
-  -------------------
-  ----TIDY SOURCE----
-  -------------------
-  My first paragraph
-
-  The second paragraph with more then two lines
-
-  the last paragraph
-  -------------------
-  */
-
-  return pSource
-};
 
 test('basic-latex', t => {
   //------------------------------
   var have = wtf.latex('that cat is [[a]] cool dude');
   var want = `that cat is \\href{./A}{a} cool dude`;
-  t.equal(latex_tidy(have), latex_tidy(want), 'link');
+  t.equal(tidy.latex(have), tidy.latex(want), 'link');
 
   have = wtf.latex('that cat is [[ab cd]] cool dude');
   want = `that cat is \\href{./Ab_cd}{ab cd} cool dude`;
-  t.equal(latex_tidy(have), latex_tidy(want), 'link-blank');
+  t.equal(tidy.latex(have), tidy.latex(want), 'link-blank');
 
     have = wtf.latex('that cat is [http://www.wikiversity.org ab cd] cool dude');
     want = `that cat is \\href{http://www.wikiversity.org}{ab cd} cool dude`;
-    t.equal(latex_tidy(have), latex_tidy(want), 'link-external');
+    t.equal(tidy.latex(have), tidy.latex(want), 'link-external');
 
     // Image simple
     have = wtf.latex(`My image [File:my_image.png]`);
     want = `My image`;
-    t.equal(latex_tidy(have), latex_tidy(want), 'one-tick');
+    t.equal(tidy.latex(have), tidy.latex(want), 'one-tick');
 
     //1 tick
     have = wtf.latex(`i 'think' so`);
     want = `i 'think' so
 `;
-    t.equal(latex_tidy(have), latex_tidy(want), 'one-tick');
+    t.equal(tidy.latex(have), tidy.latex(want), 'one-tick');
 
     //2 ticks
     have = wtf.latex(`i ''think'' so`);
     want = `i \\textit{think} so
 `;
-    t.equal(latex_tidy(have), latex_tidy(want), 'italic');
+    t.equal(tidy.latex(have), tidy.latex(want), 'italic');
 
     //3 ticks
     have = wtf.latex(`i '''think''' so`);
     want = `i \\textbf{think} so
 `;
-    t.equal(latex_tidy(have), latex_tidy(want), 'bold');
+    t.equal(tidy.latex(have), tidy.latex(want), 'bold');
 
     //4 ticks
     have = wtf.latex(`i ''''think'''' so`);
     want = `i '\\textbf{think}' so
 `;
-    t.equal(latex_tidy(have), latex_tidy(want), 'four-tick');
+    t.equal(tidy.latex(have), tidy.latex(want), 'four-tick');
 
     //5 ticks
     have = wtf.latex(`i '''''think''''' so`);
     want = `i \\textbf{\\textit{think}} so
 `;
-    t.equal(latex_tidy(have), latex_tidy(want), 'five-tick');
+    t.equal(tidy.latex(have), tidy.latex(want), 'five-tick');
 
     //itemize
     have = wtf.latex(`==My Section==\nLeading text\n* First item\n*Second Item\nClosing remark`);
@@ -118,7 +62,7 @@ test('basic-latex', t => {
     \\item Second item
   \\end{itemize}
   Closing remark`;
-    t.equal(latex_tidy(have), latex_tidy(want), 'itemize');
+    t.equal(tidy.latex(have), tidy.latex(want), 'itemize');
     //Nested itemize
     have = wtf.html(`==My Section==
   Intro text
@@ -139,7 +83,7 @@ test('basic-latex', t => {
   \\end{itemize}
   Final remarks`
   ;
-  t.equal(latex_tidy(have), latex_tidy(want), 'nested-itemize');
+  t.equal(tidy.latex(have), tidy.latex(want), 'nested-itemize');
 
     //Nested enumerate in itemize
     have = wtf.html(`Intro text
@@ -161,7 +105,7 @@ test('basic-latex', t => {
   Final remarks
   `;
 
-    t.equal(latex_tidy(have), latex_tidy(want), 'nested-itemize-enumerate');
+    t.equal(tidy.latex(have), tidy.latex(want), 'nested-itemize-enumerate');
 
   //-----------------------------
   t.end();

--- a/tests/reveal.test.js
+++ b/tests/reveal.test.js
@@ -1,34 +1,10 @@
 'use strict';
 var test = require('tape');
 var wtf = require('./lib');
+var tidy = require('./tidy');
 
+// tidy.reveal() defined in tidy.js
 
-function html_tidy(pSource) {
-  /*
-  HTML: function is necessary for smart equal compare
-  due to equivalence in exported output
-  remove unnecessary characters that makes the test smarter against
-  syntactical layout change that still provide a correct output
-  */
-
-  // (1) Comments in Output
-  pSource = pSource.replace(/<!--[^>]*-->/g,"");
-
-  // (2) Newline
-  pSource = pSource.replace(/\n/g,"");
-  // newline \n does not matter in HTML, but newlines are helpful
-  // for a more comprehensive output.
-  // Newlines can make the test fail, even if the generated code is OK.
-  // Therefore remove newlines in a tidy source
-
-  // (3) Blanks
-  // replace multiple blanks by one blank
-  pSource = pSource.replace(/\s[\s]+/g," ");
-  // remove blanks before closing a tag with ">"
-  pSource = pSource.replace(/ >/g,">");
-
-  return pSource
-};
 
 test('basic-reveal', t => {
   var have = wtf.reveal('that cat is [[a]] cool dude');
@@ -36,21 +12,21 @@ test('basic-reveal', t => {
   <p>that cat is <a class="link" href="./A">a</a> cool dude</p>
 </section>
 `;
-  t.equal(html_tidy(have), html_tidy(want), 'link');
+  t.equal(tidy.reveal(have), tidy.reveal(want), 'link');
 
   var have = wtf.reveal('that cat is [[ab cd]] cool dude');
   var want = `<section class="level2">
   <p>that cat is <a class="link" href="./Ab_cd">ab cd</a> cool dude</p>
 </section>
 `;
-  t.equal(html_tidy(have), html_tidy(want), 'link-blank');
+  t.equal(tidy.reveal(have), tidy.reveal(want), 'link-blank');
 
   var have = wtf.reveal('that cat in [http://www.wikiversity.org other Wiki] is cool');
   var want = `<section class="level2">
   <p>that cat in <a class="link external" href="http://www.wikiversity.org" target="_blank">other Wiki</a> is cool</p>
 </section>
 `;
-  t.equal(html_tidy(have), html_tidy(want), 'link-external');
+  t.equal(tidy.reveal(have), tidy.reveal(want), 'link-external');
 
   //1 tick
   have = wtf.reveal(`i 'think' so`);
@@ -58,7 +34,7 @@ test('basic-reveal', t => {
   <p>i 'think' so</p>
 </section>
 `;
-  t.equal(html_tidy(have), html_tidy(want), 'one-tick');
+  t.equal(tidy.reveal(have), tidy.reveal(want), 'one-tick');
 
   //2 ticks
   have = wtf.reveal(`i ''think'' so`);
@@ -66,7 +42,7 @@ test('basic-reveal', t => {
   <p>i <i>think</i> so</p>
 </section>
 `;
-  t.equal(html_tidy(have), html_tidy(want), 'italic');
+  t.equal(tidy.reveal(have), tidy.reveal(want), 'italic');
 
   //3 ticks
   have = wtf.reveal(`i '''think''' so`);
@@ -74,7 +50,7 @@ test('basic-reveal', t => {
   <p>i <b>think</b> so</p>
 </section>
 `;
-  t.equal(html_tidy(have), html_tidy(want), 'bold');
+  t.equal(tidy.reveal(have), tidy.reveal(want), 'bold');
 
   //4 ticks
   have = wtf.reveal(`i ''''think'''' so`);
@@ -82,7 +58,7 @@ test('basic-reveal', t => {
   <p>i '<b>think</b>' so</p>
 </section>
 `;
-  t.equal(html_tidy(have), html_tidy(want), 'four-tick');
+  t.equal(tidy.reveal(have), tidy.reveal(want), 'four-tick');
 
   //5 ticks
   have = wtf.reveal(`i '''''think''''' so`);
@@ -90,7 +66,7 @@ test('basic-reveal', t => {
   <p>i <b><i>think</i></b> so</p>
 </section>
 `;
-  t.equal(html_tidy(have), html_tidy(want), 'five-tick');
+  t.equal(tidy.reveal(have), tidy.reveal(want), 'five-tick');
 
 // thumb images are converted into single slides
   have = wtf.reveal('that is my image [[File:my_cat.png|thumb|Image "Caption" for Cat]]. Really cool');
@@ -104,7 +80,7 @@ test('basic-reveal', t => {
      Really cool
   </section>
   `;
-  t.equal(html_tidy(have), html_tidy(want), 'image-thumb-slide');
+  t.equal(tidy.reveal(have), tidy.reveal(want), 'image-thumb-slide');
 
   have = wtf.reveal('==First Slide==\nthat is my image [[File:my_cat.png|thumb|Title on Background Image]]  \n  \n==Third Slide==\nReally cool');
   want = `<section class="level2">
@@ -119,7 +95,7 @@ test('basic-reveal', t => {
      Really cool
   </section>
   `;
-  t.equal(html_tidy(have), html_tidy(want), 'image-thumb-end-section');
+  t.equal(tidy.reveal(have), tidy.reveal(want), 'image-thumb-end-section');
 
   have = wtf.reveal('[[File:my_cat.png|thumb|  ]]  \n  \n==Third Slide==\nReally cool');
   want = `<section class="level2"  data-background="https://en.wikipedia.org/wiki/Special:Redirect/file/my_cat.png">
@@ -130,7 +106,7 @@ test('basic-reveal', t => {
      Really cool
   </section>
   `;
-  t.equal(html_tidy(have), html_tidy(want), 'image-thumb-begin-slide');
+  t.equal(tidy.reveal(have), tidy.reveal(want), 'image-thumb-begin-slide');
 
   t.end();
 });

--- a/tests/tidy.js
+++ b/tests/tidy.js
@@ -82,3 +82,9 @@ function latex_tidy(pSource) {
 
   return pSource
 };
+
+module.exports = {
+  html : html_tidy,
+  latex : latex_tidy,
+  reveal : html_tidy
+}


### PR DESCRIPTION
html_tidy and latex_tidy moved to tidy.js and required that in the test.js files
Handling of relative and inter-wiki links updated.

expanding relative links in the export methods is possible but in the options the language ID e.g. "de" and the domain ID (e.g."wikiversity") is necessary to expand the relative links proper.

Export funcitons need the domain and language in options to expand the Links and image urls.
Thank you Spencer