### PR TITLE
Handle queries with invalid characters.

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -33,7 +33,7 @@ const postProcess = function(data) {
   let pages = Object.keys(data.query.pages);
   let docs = pages.map(id => {
     let page = data.query.pages[id] || {};
-    if (page.hasOwnProperty('missing')) {
+    if (page.hasOwnProperty('missing') || page.hasOwnProperty('invalid')) {
       return null;
     }
     let text = page.revisions[0]['*'];

--- a/tests/fetch.test.js
+++ b/tests/fetch.test.js
@@ -26,3 +26,27 @@ test('fetch-as-callback', t => {
     t.ok(doc.categories().length > 0, 'callback returned document');
   });
 });
+
+test('fetch-invalid', t => {
+  t.plan(1);
+  var p = wtf.fetch('Taylor%20Swift', 'en', {
+    'Api-User-Agent': 'wtf_wikipedia test script - <spencermountain@gmail.com>'
+  });p.then(function(doc) {
+    t.ok(doc === null, 'invalid character query returns null');
+  });
+  p.catch(function(e) {
+    t.throw(e);
+  });
+});
+
+test('fetch-missing', t => {
+  t.plan(1);
+  var p = wtf.fetch('NonExistentPage', 'en', {
+    'Api-User-Agent': 'wtf_wikipedia test script - <spencermountain@gmail.com>'
+  });p.then(function(doc) {
+    t.ok(doc === null, 'fetching non-existent page returns null');
+  });
+  p.catch(function(e) {
+    t.throw(e);
+  });
+});


### PR DESCRIPTION
Bare queries that contain invalid characters (eg 'Taylor%20Swift', which is encoded as 'Taylor%2520Swift') return an object with the 'invalid' property set. This case differs from the one that was already handled for missing pages (the 'missing' property is set).
This PR addresses the invalid character case and also adds tests for both cases.
An example query directly against the API:
https://en.wikipedia.org/w/api.php?action=query&redirects=true&prop=revisions&rvprop=content&maxlag=5&format=json&origin=*&titles=Taylor%2520Swift