### PR TITLE
Add support for currency templates

### DIFF
--- a/src/templates/currencies.js
+++ b/src/templates/currencies.js
@@ -1,0 +1,47 @@
+const pipeSplit = require('./parsers/pipeSplit');
+
+const currencyTemplateCodes = {
+  us$: 'US$', // https://en.wikipedia.org/wiki/Template:US$
+  bdt: '৳', // https://en.wikipedia.org/wiki/Template:BDT
+  a$: 'A$', // https://en.wikipedia.org/wiki/Template:AUD
+  ca$: 'CA$', // https://en.wikipedia.org/wiki/Template:CAD
+  cny: 'CN¥', // https://en.wikipedia.org/wiki/Template:CNY
+  hkd: 'HK$', // https://en.wikipedia.org/wiki/Template:HKD
+  gbp: 'GB£', // https://en.wikipedia.org/wiki/Template:GBP
+  '₹': '₹', // https://en.wikipedia.org/wiki/Template:Indian_Rupee
+  '¥': '¥', // https://en.wikipedia.org/wiki/Template:JPY
+  jpy: '¥',
+  yen: '¥',
+  '₱': '₱', // https://en.wikipedia.org/wiki/Template:Philippine_peso
+  pkr: '₨', // https://en.wikipedia.org/wiki/Template:Pakistani_Rupee
+};
+
+const templateForCurrency = currency => tmpl => {
+  const { year, value } = pipeSplit(tmpl, ['value', 'year']);
+  // Ignore round, about, link options
+  if (year) {
+    // Don't perform inflation adjustment
+    return `${currency}${value} (${year})`;
+  }
+  if (value) {
+    return `${currency}${value}`;
+  }
+  return currency;
+};
+
+const currencies = Object.keys(currencyTemplateCodes).reduce(
+  (result, code) => {
+    result[code] = templateForCurrency(currencyTemplateCodes[code]);
+    return result;
+  },
+  {
+    // https://en.wikipedia.org/wiki/Template:Currency
+    currency: tmpl => {
+      // Ignore first and linked options
+      const { code, amount } = pipeSplit(tmpl, ['amount', 'code']);
+      return `${code}${amount}`;
+    },
+  },
+);
+
+module.exports = currencies;

--- a/src/templates/index.js
+++ b/src/templates/index.js
@@ -5,6 +5,7 @@ const getTemplates = require('./parsers/_getTemplates');
 const dates = require('./dates');
 const geo = require('./geo');
 const inline = require('./inline');
+const currencies = require('./currencies');
 const misc = require('./misc');
 const generic = require('./generic');
 const links = require('./links');
@@ -14,7 +15,14 @@ const external = require('./external');
 const ignore = require('./ignore');
 
 //put them all together
-const inlineParsers = Object.assign({}, dates, inline, links, formatting);
+const inlineParsers = Object.assign(
+  {},
+  dates,
+  inline,
+  currencies,
+  links,
+  formatting,
+);
 const bigParsers = Object.assign({}, geo, pronounce, misc, external);
 
 const doTemplate = function(tmpl, wiki, r) {
@@ -25,7 +33,7 @@ const doTemplate = function(tmpl, wiki, r) {
     return wiki;
   }
   //string-replacement templates
-  if ((inlineParsers.hasOwnProperty(name) === true ) && (inlineParsers[name])) {
+  if (inlineParsers.hasOwnProperty(name) === true && inlineParsers[name]) {
     let str = inlineParsers[name](tmpl, r);
     wiki = wiki.replace(tmpl, str);
     return wiki;
@@ -59,13 +67,13 @@ const allTemplates = function(r, wiki, options) {
   let templates = getTemplates(wiki);
   // console.log(templates);
   //first, do the nested ones
-  templates.nested.forEach((tmpl) => {
+  templates.nested.forEach(tmpl => {
     wiki = doTemplate(tmpl, wiki, r, options);
   });
   // console.log(wiki);
   //then, reparse wiki for the top-level ones
   templates = getTemplates(wiki);
-  templates.top.forEach((tmpl) => {
+  templates.top.forEach(tmpl => {
     wiki = doTemplate(tmpl, wiki, r, options);
   });
   return wiki;

--- a/tests/template.test.js
+++ b/tests/template.test.js
@@ -218,3 +218,80 @@ hello there
   t.equal(doc.templates('infobox').length, 1, 'got infobox template');
   t.end();
 });
+
+var microsoft = `
+{{Infobox company
+| name = Microsoft Corporation
+| logo = Microsoft logo and wordmark.svg
+| logo_alt = A square divided into four sub-squares, colored red, green, yellow and blue (clockwise), with the company name appearing to its right.
+| image = Microsoft building 17 front door.jpg
+| image_caption = Building 17 on the [[Microsoft Redmond campus]] in [[Redmond, Washington]]
+| type = [[Public company|Public]]
+| traded_as = {{Unbulleted list|{{NASDAQ|MSFT}}|[[NASDAQ-100|NASDAQ-100 component]]|[[Dow Jones Industrial Average|DJIA component]]|[[S&P 100|S&P 100 component]]|[[S&P 500|S&P 500 component]]}}
+| ISIN = US5949181045
+| industry = {{Unbulleted list|[[Computer software]]|[[Computer hardware]]|[[Consumer electronics]]|[[Social networking service]]|[[Cloud computing]]|[[Video game industry|Video games]]|[[Internet]]|[[Corporate venture capital]]}}
+| founded = {{Start date and age|1975|04|04}} in [[Albuquerque, New Mexico|Albuquerque]], [[New Mexico]], U.S.
+| founders = {{Plainlist|
+* [[Bill Gates]]
+* [[Paul Allen]]
+}}
+| hq_location = [[Microsoft Redmond campus]]
+| hq_location_city = [[Redmond, Washington|Redmond]], [[Washington (state)|Washington]]
+| hq_location_country = [[United States|U.S.]]
+| area_served = Worldwide
+| key_people = {{Plainlist|
+* [[John W. Thompson]] ([[Chairman]])
+* [[Brad Smith (American lawyer)|Brad Smith]] ([[President (corporate title)|President]] and [[Chief legal officer|CLO]])
+* [[Satya Nadella]] ([[Chief executive officer|CEO]])
+* [[Bill Gates]] ([[Technical advisor]])
+}}
+| products = {{Flatlist|
+* [[Microsoft Windows|Windows]]
+* [[Microsoft Office|Office]]
+* [[Microsoft Servers|Servers]]
+* [[Skype]]
+* [[Microsoft Visual Studio|Visual Studio]]
+* [[Microsoft Dynamics|Dynamics]]
+* [[Xbox]]
+* [[Microsoft Surface|Surface]]
+* [[Microsoft Mobile|Mobile]]
+* [[List of Microsoft software|more...]]
+}}
+| services = {{Flatlist|
+* [[Microsoft Azure|Azure]]
+* [[Bing (search engine)|Bing]]
+* [[LinkedIn]]
+* [[Microsoft Developer Network|MSDN]]
+* [[Office 365]]
+* [[OneDrive]]
+* [[Outlook.com]]
+* [[Microsoft TechNet|TechNet]]
+* [[Microsoft Wallet|Wallet]]
+* [[Windows Store]]
+* [[Windows Update]]
+* [[Xbox Live]]
+}}
+| revenue = {{Increase}} {{US$|89.95&nbsp;billion|link=yes}}<ref name="xbrlus_1">{{cite web |date=July 21, 2016 |url=https://www.microsoft.com/en-us/Investor/earnings/FY-2017-Q4/press-release-webcast |title=Microsoft Form 10-K, Fiscal Year Ended June 30, 2017 |publisher=[[U.S. Securities and Exchange Commission]] |accessdate=June 18, 2017 |website=https://sec.gov}}</ref>
+| revenue_year = 2017
+| operating_income = {{Increase}} {{US$|22.27&nbsp;billion}}<ref name="xbrlus_1" />
+| income_year = 2017
+| net_income = {{Increase}} {{US$|21.20&nbsp;billion}}<ref name="xbrlus_1" />
+| net_income_year = 2017
+| assets = {{Increase}} {{US$|241.08&nbsp;billion}}<ref name="xbrlus_1" />
+| assets_year = 2017
+| equity = {{Increase}} {{US$|72.39&nbsp;billion}}<ref name="xbrlus_1" />
+| equity_year = 2017
+| num_employees = 124,000<ref name="xbrlus_1" />
+| num_employees_year = 2016
+| subsid = [[List of mergers and acquisitions by Microsoft|List of Microsoft subsidiaries]]
+| website = {{URL|https://microsoft.com}}
+}}
+`;
+
+test('currency parsing', function(t) {
+  var infobox = wtf(microsoft).infoboxes(0).data;
+  t.equal(infobox.revenue.text(), 'US$89.95 billion', 'revenue =' + infobox.revenue.text);
+  t.equal(infobox.operating_income.text(), 'US$22.27 billion', 'operating_income =' + infobox.operating_income.text);
+  t.equal(infobox.net_income.text(), 'US$21.20 billion', 'net_income =' + infobox.net_income.text);
+  t.end();
+});


### PR DESCRIPTION
Currency templates were being ignored. Try e.g. parsing the Microsoft Wikipedia page, which results in an incomplete infobox.

This adds support for the currencies templates that I found.

Sorry for the few formatting changes – they were automatically added by prettier. I can add a commit that undoes them if needed.