### PR TITLE
Fix issue with spaces before and after file name

### DIFF
--- a/src/image/Image.js
+++ b/src/image/Image.js
@@ -11,7 +11,7 @@ const encodeTitle = function(file) {
   //titlecase it
   title = title.charAt(0).toUpperCase() + title.substring(1);
   //spaces to underscores
-  title = title.replace(/ /g, '_');
+  title = title.trim().replace(/ /g, '_');
   return title;
 };
 


### PR DESCRIPTION
Because of this issue image urls are created wrongly https://upload.wikimedia.org/wikipedia/commons/thumb/b/bf/_AppleTV-4th-gen.png/300px-_AppleTV-4th-gen.png
