### PR TITLE
Added additional html elements to conversion scripts

### DIFF
--- a/src/document/toHtml.js
+++ b/src/document/toHtml.js
@@ -3,16 +3,27 @@
 const toHtml = function(doc, options) {
   let data = doc.data;
   let html = '';
-  //add the title on the topw
-  // if (options.title === true && data.title) {
-  //   html += '<h1>' + data.title + '</h1>\n';
-  // }
+  html += '<!DOCTYPE html>\n';
+  html += '<html>\n';
+  html += '<head>\n';
+  //add page title
+   if (options.title === true && data.title) {
+     html += '<title>' + data.title + ' - Wikipedia' + '</title>\n';
+   }
+  html += '</head>\n';
+  html += '<body>\n';
+  //add header 
+   if (options.title === true && data.title) {
+     html += '<h1>' + data.title +  '</h1>\n';
+   }
   //render infoboxes (up at the top)
   if (options.infoboxes === true && data.infoboxes) {
     html += data.infoboxes.map(i => i.html(options)).join('\n');
   }
   //render each section
   html += data.sections.map(s => s.html(options)).join('\n');
+  html += '</body>\n';
+  html += '</html>\n';
   return html;
 };
 module.exports = toHtml;

--- a/src/list/List.js
+++ b/src/list/List.js
@@ -5,7 +5,7 @@ const toHtml = (list) => {
   list.forEach((o) => {
     html += '  <li>' + o.text() + '</li>\n';
   });
-  html += '<ul>\n';
+  html += '</ul>\n';
   return html;
 };
 

--- a/tests/html.test.js
+++ b/tests/html.test.js
@@ -5,62 +5,98 @@ var tidy = require('./lib/tidy');
 
 test('basic-html', t => {
   var have = wtf('that cat is [[a]] cool dude').html();
-  var want = `<div class="section">
+  var want = `<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+<div class="section">
   <div class="text">
     <span class="sentence">that cat is <a class="link" href="./A">a</a> cool dude</span>
   </div>
 </div>
+</body>
+</html>
 `;
   t.equal(tidy.html(have), tidy.html(want), 'link');
 
   //1 tick
   have = wtf(`i 'think' so`).html();
-  want = `<div class="section">
+  want = `<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+<div class="section">
   <div class="text">
     <span class="sentence">i 'think' so</span>
   </div>
 </div>
+</body>
+</html>
 `;
   t.equal(tidy.html(have), tidy.html(want), 'link-blank');
 
 
   //2 ticks
   have = wtf(`i ''think'' so`).html();
-  want = `<div class="section">
+  want = `<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+<div class="section">
   <div class="text">
     <span class="sentence">i <i>think</i> so</span>
   </div>
 </div>
+</body>
+</html>
 `;
-  t.equal(have, want, 'italic');
+  t.equal(tidy.html(have), tidy.html(want), 'italic');
 
   //3 ticks
   have = wtf(`i '''think''' so`).html();
-  want = `<div class="section">
+  want = `<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+<div class="section">
   <div class="text">
     <span class="sentence">i <b>think</b> so</span>
   </div>
 </div>
+</body>
+</html>
 `;
-  t.equal(have, want, '3-ticks');
+  t.equal(tidy.html(have), tidy.html(want), '3-ticks');
 
   //4 ticks
   have = wtf(`i ''''think'''' so`).html();
-  want = `<div class="section">
+  want = `<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+<div class="section">
   <div class="text">
     <span class="sentence">i '<b>think</b>' so</span>
   </div>
 </div>
+</body>
+</html>
 `;
   t.equal(tidy.html(have), tidy.html(want), '4 ticks');
 
   //5 ticks
   have = wtf(`i '''''think''''' so`).html();
-  want = `<div class="section">
+  want = `<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+<div class="section">
   <div class="text">
     <span class="sentence">i <b><i>think</i></b> so</span>
   </div>
 </div>
+</body>
+</html>
 `;
   t.equal(tidy.html(have), tidy.html(want), '5-ticks');
 


### PR DESCRIPTION
I added a doctype string and some additional elements to the html conversion to match the output of the converter with standard html format (#168).
There was also a small bug in the list to html conversion, where the closing tag was missing a `/`. 
The html tests were also updated to reflect those updates.

Let me know if there are any issues with the changes.
Cheers