### PR TITLE
Write start and end tags of thead into separate lines

### DIFF
--- a/src/infobox/toHtml.js
+++ b/src/infobox/toHtml.js
@@ -8,7 +8,8 @@ const dontDo = {
 //
 const infobox = function(obj, options) {
   let html = '<table class="infobox">\n';
-  html += '  <thead></thead>\n';
+  html += '  <thead>\n';
+  html += '  </thead>\n';
   html += '  <tbody>\n';
   //put image and caption on the top
   if (obj.data.image) {


### PR DESCRIPTION
Minor change to put start and end tags of infobox `thead` into different lines. This follows the formatting used for the other converted tables. Also, lxml seemed to not like the previous format.