### PR TITLE
Use a for loop instead of a higher-order function

### DIFF
--- a/src/templates/parsers/_getTemplates.js
+++ b/src/templates/parsers/_getTemplates.js
@@ -13,7 +13,8 @@ const findFlat = function(wiki) {
   let list = [];
   let carry = [];
   let chars = wiki.split('');
-  chars.forEach((c) => {
+  for(var i = 0; i < chars.length; i++) {
+    c = chars[i];
     //open it
     if (c === open) {
       depth += 1;
@@ -29,19 +30,18 @@ const findFlat = function(wiki) {
           if (/\{\{/.test(tmpl) && /\}\}/.test(tmpl)) {
             list.push(tmpl);
           }
-          return;
+          continue;
         }
       }
       //require two '{{' to open it
       if (depth === 1 && c !== open && c !== close) {
         depth = 0;
         carry = [];
-        return;
+        continue;
       }
       carry.push(c);
-      return;
     }
-  });
+  }
   return list;
 };
 


### PR DESCRIPTION
This saves about 4% of parse time when benchmarked against 
https://dumps.wikimedia.org/enwiki/latest/enwiki-latest-pages-articles14.xml-p7697599p7744799.bz2

Not huge, but every little bit helps!