### PR TITLE
Miscellaneous performance improvements

### DIFF
--- a/src/lib/recursive_match.js
+++ b/src/lib/recursive_match.js
@@ -4,33 +4,40 @@
 function find_recursive(opener, closer, text) {
   var out = [];
   var last = [];
-  var chars = text.split('');
+  const chars = text.split('');
   var open = 0;
   for (var i = 0; i < chars.length; i++) {
+    const c = text[i];
     //increment open tag
-    if (chars[i] === opener) {
+    if (c === opener) {
       open += 1;
     }
     //decrement close tag
-    if (chars[i] === closer) {
+    else if (c === closer) {
       open -= 1;
       if (open < 0) {
         open = 0;
       }
+    } else if (last.length == 0) {
+      // If we're not inside of a pair of delimiters, we can discard the current letter.
+      // The return of this function is only used to extract images.
+      continue;
     }
-    if (open >= 0) {
-      last.push(chars[i]);
-    }
+
+    last.push(c);
     if (open === 0 && last.length > 0) {
       //first, fix botched parse
-      var open_count = last.filter(function(s) {
-        return s === opener;
-      });
-      var close_count = last.filter(function(s) {
-        return s === closer;
-      });
+      var open_count = 0;
+      var close_count = 0;
+      for (var j = 0; j < last.length; j++) {
+        if (last[j] === opener) {
+          open_count++;
+        } else if (last[j] === closer) {
+          close_count++;
+        }
+      }
       //is it botched?
-      if (open_count.length > close_count.length) {
+      if (open_count > close_count) {
         last.push(closer);
       }
       //looks good, keep it

--- a/src/templates/parsers/_getTemplates.js
+++ b/src/templates/parsers/_getTemplates.js
@@ -12,9 +12,8 @@ const findFlat = function(wiki) {
   let depth = 0;
   let list = [];
   let carry = [];
-  let chars = wiki.split('');
-  for(var i = 0; i < chars.length; i++) {
-    c = chars[i];
+  for (var i = wiki.indexOf(open); i != -1 && i < wiki.length; depth > 0 ? i++ : (i = wiki.indexOf(open, i + 1))) {
+    c = wiki[i];
     //open it
     if (c === open) {
       depth += 1;
@@ -24,7 +23,8 @@ const findFlat = function(wiki) {
       if (c === close) {
         depth -= 1;
         if (depth === 0) {
-          let tmpl = carry.join('') + c;
+          carry.push(c);
+          let tmpl = carry.join('');
           carry = [];
           //last check
           if (/\{\{/.test(tmpl) && /\}\}/.test(tmpl)) {


### PR DESCRIPTION
Two main things:

- in findFlat, skip runs of characters between close and open delimiters

- in find_recursive, remove an if that is always true and avoid
   appending characters that will be ignored by the downstream caller

This improved the runtime of my performance harness from ~8s to ~6.6s,
about an ~18% decrease in runtime.

I'm less sure about this change - I'll call out the specific concerns in the PR.