### PR TITLE
add ability to pass wikiUrl as an option to wtf.fetch to override wikipedia url

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -15,8 +15,14 @@ const makeUrl = function(title, lang, options) {
   if (site_map[lang]) {
     url = site_map[lang] + '/w/api.php';
   }
+  if (options.wikiUrl) {
+    url = options.wikiUrl;
+  }
   //we use the 'revisions' api here, instead of the Raw api, for its CORS-rules..
-  url += '?action=query&prop=revisions&rvprop=content&maxlag=5&format=json&origin=*';
+  url += '?action=query&prop=revisions&rvprop=content&maxlag=5&format=json';
+  if (!options.wikiUrl) {
+    url += '&origin=*';
+  }
   if (options.follow_redirects !== false) {
     url += '&redirects=true';
   }

--- a/tests/fetch.test.js
+++ b/tests/fetch.test.js
@@ -67,6 +67,20 @@ test('fetch-redirect', t => {
   });
 });
 
+test('fetch-alternate-wiki', t => {
+  t.plan(1);
+  var p = wtf.fetch(336711, 'en', {
+    'Api-User-Agent': 'wtf_wikipedia test script - <spencermountain@gmail.com>',
+    wikiUrl: 'https://www.mixesdb.com/db/api.php'
+  });
+  p.then(function(doc) {
+    t.ok(doc.sections().length > 0, 'alternate wiki returned document');
+  });
+  p.catch(function(e) {
+    t.throw(e);
+  });
+});
+
 //uncomment for testing on node>6
 /*
 test('ambiguous-pageids', async function(t) {


### PR DESCRIPTION
Right now in a personal project I'm getting the data first from https://www.mixesdb.com/db/api.php and then feeding it into wtf but I figured a change like this would make it much more concise and could be useful for other people (although I've not actually tested it with other wikis).

Love the project by the way! Saved so much time