### PR TITLE
Add japanese locale support to i18n.js

### DIFF
--- a/src/_data/i18n.js
+++ b/src/_data/i18n.js
@@ -16,7 +16,8 @@ let i18n = {
     'bestand',
     'датотека',
     'dosya',
-    'fil'
+    'fil',
+    'ファイル'
   ],
   images: ['image'],
   templates: [
@@ -94,7 +95,8 @@ let i18n = {
     'spécial',
     'speciaal',
     'посебно',
-    'özel'
+    'özel',
+    '特別'
   ],
   users: [
     'удзельнік',
@@ -110,7 +112,8 @@ let i18n = {
     'utilisateur',
     'gebruiker',
     'корисник',
-    'kullanıcı'
+    'kullanıcı',
+    '利用者'
   ],
   disambigs: [
     'disambig', //en
@@ -127,7 +130,8 @@ let i18n = {
     'desambiguação', //pt
     'homonymie', //fr
     'неоднозначность', //ru
-    'anlam ayrımı' //tr
+    'anlam ayrımı', //tr
+    '曖昧さ回避' //ja
   ],
   infoboxes: [
     'infobox',
@@ -148,7 +152,11 @@ let i18n = {
     'further reading',
     'notes et références',
     'voir aussi',
-    'liens externes'
+    'liens externes',
+    '参考文献', //references (ja)
+    '脚注', //citations (ja)
+    '関連項目', //see also (ja)
+    '外部リンク' //external links (ja)
   ]
 };
 


### PR DESCRIPTION
wtf great module is this! By the way I needed Japanese support for this, then I added.

References
- https://ja.wikipedia.org/wiki/Help:%E5%90%8D%E5%89%8D%E7%A9%BA%E9%96%93
- https://ja.wikipedia.org/wiki/Wikipedia:%E6%9B%96%E6%98%A7%E3%81%95%E5%9B%9E%E9%81%BF