### PR TITLE
Add references to JSON output for sections

### DIFF
--- a/src/02-section/toJson.js
+++ b/src/02-section/toJson.js
@@ -10,6 +10,7 @@ const defaults = {
   templates: true,
   infoboxes: true,
   lists: true,
+  references: true
 };
 //
 const toJSON = function(section, options) {
@@ -65,6 +66,13 @@ const toJSON = function(section, options) {
     let lists = section.lists().map(list => list.json(options));
     if (lists.length > 0) {
       data.lists = lists;
+    }
+  }
+  //list references - default true
+  if (options.references === true) {
+    let references = section.references().map(ref => ref.json(options));
+    if (references.length > 0) {
+      data.references = references;
     }
   }
   //default off


### PR DESCRIPTION
References aren't currently added to the JSON output of a section, and therefore don't show up in the JSON output of the overall document either. This small code additions adds that ability so references can be outputted. 