### PR TITLE
Add support for wikiUrl option in .category

### DIFF
--- a/src/_fetch/category.js
+++ b/src/_fetch/category.js
@@ -10,11 +10,14 @@ const normalizeCategory = function( cat = '' ) {
   return cat;
 };
 
-const makeUrl = function(cat, lang) {
+const makeUrl = function(cat, lang, options) {
   cat = encodeURIComponent(cat);
   let url = `https://${lang}.wikipedia.org/w/api.php`;
   if (site_map[lang]) {
     url = site_map[lang] + '/w/api.php';
+  }
+  if (options.wikiUrl) {
+    url = options.wikiUrl;
   }
   url += `?action=query&list=categorymembers&cmtitle=${cat}&cmlimit=500&format=json&origin=*&redirects=true&cmtype=page|subcat`;
   return url;


### PR DESCRIPTION
Just noticed that `.fetch` supports using other MediaWiki urls, but not `.category`.

I needed this for a side project, and tested it using my fork, and it seems to work.
Any reason this was left out?

Thanks! :wave: 