### PR TITLE
Add support for some French infobox keys: siège (ville), siège (pays)…

### DIFF
--- a/src/templates/_parsers/02-keyMaker.js
+++ b/src/templates/_parsers/02-keyMaker.js
@@ -1,6 +1,6 @@
 // every value in {{tmpl|a|b|c}} needs a name
 // here we come up with names for them
-const hasKey = /^[a-z0-9\u00C0-\u00FF\._\- ']+=/iu
+const hasKey = /^[a-z0-9\u00C0-\u00FF\._\- '()œ]+=/iu
 
 //templates with these properties are asking for trouble
 const reserved = {

--- a/src/templates/formatting/format.js
+++ b/src/templates/formatting/format.js
@@ -165,6 +165,7 @@ templates['rndnear'] = templates.rnd;
 //templates that we simply grab their insides as plaintext
 let inline = [
   'nowrap',
+  'nobr',
   'big',
   'cquote',
   'pull quote',

--- a/tests/infobox.test.js
+++ b/tests/infobox.test.js
@@ -25,6 +25,8 @@ test('french-infobox', function(t) {
   | titre blanc               = oui
   | nom                       = Microsoft Corporation
   | secteurs d'activités      = found1
+  | siège (ville)             = city
+  | société sœur              = sister
   | chiffre d'affaires        = found2
  }}
 `
@@ -33,5 +35,7 @@ test('french-infobox', function(t) {
     .keyValue()
   t.equal(obj[`secteurs d'activités`], 'found1', 'found secteurs val')
   t.equal(obj[`chiffre d'affaires`], 'found2', 'found chiffre val')
+  t.equal(obj[`siège (ville)`], 'city', 'found city val')
+  t.equal(obj[`société sœur`], 'sister', 'found sister val')
   t.end()
 })

--- a/tests/more-templates.test.js
+++ b/tests/more-templates.test.js
@@ -72,12 +72,14 @@ test('support-nowrap-in-infobox', t => {
   | spouse      = {{nowrap| {{marriage|[[Elsa Löwenthal]]<br>|1919|1936|end=died}} }}
   | residence   = Germany, Italy, Switzerland, Austria (present-day Czech Republic), Belgium, United States
   | signature = Albert Einstein signature 1934.svg
+  | chiffre = {{nobr|912 millions}}
   }}
   `;
   var infobox = wtf(str).infoboxes(0);
   var data = infobox.json();
   t.equal(data.name.text, 'Albert Einstein', 'got infobox datad');
   t.equal(data.spouse.text, 'Elsa Löwenthal (m. 1919-1936)', 'got tricky marriage value');
+  t.equal(data.chiffre.text, '912 millions', 'got infobox nobr');
   t.end();
 });
 


### PR DESCRIPTION
Hello,
Here is my first PR attempt in this nice project.

Added support for some French infobox keys: siège (ville), siège (pays), société sœur.
Example usage https://fr.wikipedia.org/wiki/Société_française_du_tunnel_routier_du_Fréjus
Also added nobr which is synonym for nowrap.

Note: I work on Windows so I was not able to run the tests from my laptop (not a surprise, that's ok).
I then tried on Ubuntu and most tests passed except 2:
stress.test.js line 62 and 105: ENOENT: no such file or directory, open '/mongoxfs/wiki/wtf_wikipedia/tests/cache/Magnar-Sætre.txt'
templates-inline.test.js line 131 f(x) = b x = y
I commented these lines then all tests passed.

Thanks!