### PR TITLE
fix Sentence.text definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -460,10 +460,10 @@ declare module wtf {
 
     dates(): string[]
 
-    text(str: string | null | undefined): string
+    text(str?: string): string
 
     /** Alias of text */
-    plaintext(str: string | null | undefined): string
+    plaintext(str?: string): string
 
     markdown(options?: object): string
 


### PR DESCRIPTION
As far as I can tell, "str" is an optional parameter but in the definition it's required but can be nothing. Should let `.text()` work instead of requiring `.text(undefined)`.