### PR TITLE
Expand type for fetch primary parameter

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -15,14 +15,14 @@ declare module wtf {
   export function category(cat: string, lang?: string, options?: object, cb?: any): Promise<object>
 
   export function fetch(
-    title: string,
+    titleOrId: string | number,
     lang?: string,
     options?: any,
     cb?: any
   ): Promise<null | Document>
 
   export function fetch(
-    titles: string[],
+    titlesOrIds: string[] | number[],
     lang?: string,
     options?: any,
     cb?: any


### PR DESCRIPTION
Hi 👋

The purpose of this PR is to include numbers in the type definition for the fetch method's primary parameter and take into account the fact that IDs can be used to identify pages not just titles.

This is my first PR to the repo. Let me know if you have any feedback!