### PR TITLE
Make abbreviations regex more restrictive

### DIFF
--- a/src/04-sentence/parse.js
+++ b/src/04-sentence/parse.js
@@ -4,7 +4,8 @@
 //(Rule-based sentence boundary segmentation) - chop given text into its proper sentences.
 // Ignore periods/questions/exclamations used in acronyms/abbreviations/numbers, etc.
 // @spencermountain 2015 MIT
-const abbreviations = require('../_data/abbreviations')
+const literalAbbreviations = require('../_data/abbreviations')
+const abbreviations = literalAbbreviations.concat('[^]][^]]')
 const abbrev_reg = new RegExp("(^| |')(" + abbreviations.join('|') + `)[.!?] ?$`, 'i')
 const acronym_reg = new RegExp('[ |.][A-Z].? +?$', 'i')
 const elipses_reg = new RegExp('\\.\\.\\.* +?$')

--- a/src/_data/abbreviations.js
+++ b/src/_data/abbreviations.js
@@ -142,6 +142,5 @@ module.exports = [
   'ex',
   'eg',
   'sep',
-  'sept',
-  '..'
+  'sept'
 ]


### PR DESCRIPTION
Hi,

This PR is proposed as a fix for #267. In particular, it modifies the abbreviations regex to prevent the incorrect categorisation of sentences.

Let me know if you have any feedback.