### PR TITLE
Fixed handling of newlines within table cells. closes #332

### DIFF
--- a/src/02-section/table/parse/index.js
+++ b/src/02-section/table/parse/index.js
@@ -93,8 +93,10 @@ const firstRowHeader = function(rows) {
 
 //turn a {|...table string into an array of arrays
 const parseTable = function(wiki) {
-  let lines = wiki.replace(/\r/g, '').split(/\n/)
-  lines = lines.map(l => l.trim())
+  let lines = wiki.replace(/\r/g, '')
+    .replace(/\n(\s*[^|!{\s])/g, ' $1')//remove unecessary newlines
+    .split(/\n/)
+    .map(l => l.trim())
   let rows = findRows(lines)
   //support colspan, rowspan...
   rows = handleSpans(rows)

--- a/tests/table.test.js
+++ b/tests/table.test.js
@@ -486,7 +486,7 @@ test('junky-table', t => {
   t.end()
 })
 
-test('table newlines', t => {
+test('table double bar', t => {
   var str = `{| class="wikitable"
 |-
 ! h1
@@ -514,5 +514,33 @@ test('table newlines', t => {
   t.equal(data[2].h1, 'c', 'h1')
   t.equal(data[2].h2, 'cc', 'h2')
   t.equal(data[2].h3, 'ccc', 'h3')
+  t.end()
+})
+
+//testing https://github.com/spencermountain/wtf_wikipedia/issues/332
+test('table newline', t => {
+  var str = `{| class="wikitable"
+|-
+! h1
+! h2
+! h3
+|-
+| a
+| b1<br />b2
+| c
+|-
+| a
+| b1
+b2
+| c
+|}`
+  var doc = wtf(str)
+  var data = doc.tables(0).keyValue()
+  t.equal(data[0].h1, 'a', 'h1')
+  t.equal(data[0].h2, 'b1 b2', 'h2')
+  t.equal(data[0].h3, 'c', 'h3')
+  t.equal(data[0].h1, 'a', 'h1')
+  t.equal(data[0].h2, 'b1 b2', 'h2')
+  t.equal(data[0].h3, 'c', 'h3')
   t.end()
 })


### PR DESCRIPTION
I believe this fixes #332 (all tests pass and added a new one for the specific issue).

I'm not totally in love with the regex approach - however I started by trying to detect this situation and append the current line on to the end of the previous one as we are iterating the lines, but it got messy and this seemed much cleaner.

Note this change doesn't perfectly represent the behavior of the wikipedia parser, because we now respect a `||` in the line after a line break, whereas wikipedia only allows it after a `<br />` and not after a 'manual' newline - but I haven't worried about that because I can't imagine anyone actually _cares_.