### PR TITLE
Allowing the User-Agent header to be set

### DIFF
--- a/src/_fetch/_request.js
+++ b/src/_fetch/_request.js
@@ -1,15 +1,19 @@
 const fetch = require('cross-fetch')
 
 const request = function(url, options) {
+  const fallbackUserAgent = 'Random user of the wtf_wikipedia library'
   let params = {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
       'Api-User-Agent':
+        options['Api-User-Agent'] ||
+        fallbackUserAgent,
+      'User-Agent':
         options.userAgent ||
         options['User-Agent'] ||
         options['Api-User-Agent'] ||
-        'Random user of the wtf_wikipedia library'
+        fallbackUserAgent
     }
   }
   return fetch(url, params)

--- a/tests/fetch.test.js
+++ b/tests/fetch.test.js
@@ -135,3 +135,31 @@ test('ambiguous-pageids', async function(t) {
   t.end();
 });
 */
+
+test('intensive', t => {
+  /* fires a bunch of requests in parallel - this should be enough to get blocked by wikipedia if the user agent is not set correctly */
+  var pages = [
+    'Mouse',
+    'Rat',
+    'Porcupine',
+    'Chipmunk',
+    'Vole',
+    'Chinchilla',
+    'Gopher',
+    'Capybara',
+    'Beaver',
+    'Hamster'
+  ];
+  t.plan(pages.length)
+  var promises = pages.map(page => wtf.fetch(page, 'en', {
+    'Api-User-Agent': 'wtf_wikipedia test script - <spencermountain@gmail.com>'
+  }))
+  Promise.all(promises).then(results => {
+    results.forEach(result => {
+      t.ok(result.title(), 'got a page')
+    })
+    t.end();
+  }).catch((e) => {
+    t.error(e, e)
+  })
+})


### PR DESCRIPTION
Sets the `User-Agent` header in addition to `Api-User-Agent` when making requests. The wikimedia docs are unclear on the difference, but my testing shows that the latter is not sufficient if you're also setting a common `User-Agent` header (which was the case here, as it defaulted to the header set by the `fetch` library).

This changes allows `User-Agent` and `Api-User-Agent` to be set independently, however for backwards compatability if your config has `Api-User-Agent` but not `User-Agent` then the value from `Api-User-Agent` will be copied to the `User-Agent` header.

Fixes #334.