### PR TITLE
Add support for complex interwiki links

### DIFF
--- a/src/link/interwiki.js
+++ b/src/link/interwiki.js
@@ -19,11 +19,21 @@ const parseInterwiki = function(obj) {
     }
     let site = m[1] || ''
     site = site.toLowerCase()
-    //only allow interwikis to these specific places
-    if (interwikis.hasOwnProperty(site) === false) {
-      return obj
+    if (site.indexOf(':') !== -1) {
+      let [, wiki, lang] = site.match(/^:?(.*):(.*)/)
+      //only allow interwikis to these specific places
+      if (
+        interwikis.hasOwnProperty(wiki) && languages.hasOwnProperty(lang) === false
+      ) {
+        return obj
+      }
+      obj.wiki = { wiki: wiki, lang: lang }
+    } else {
+      if (interwikis.hasOwnProperty(site) === false) {
+        return obj
+      }
+      obj.wiki = site
     }
-    obj.wiki = site
     obj.page = m[2]
   }
   return obj

--- a/tests/interwiki.test.js
+++ b/tests/interwiki.test.js
@@ -21,6 +21,14 @@ test('expand external interwiki link', t => {
 
   let href = doc.link().href()
   t.equal(href, 'http://heroeswiki.com/cool', 'expand external link')
+
+  str = `[[Wiktionary:fr:bonjour]]`
+  doc = wtf(str)
+  obj = doc.link().json()
+  t.equal(obj.type, 'interwiki', 'interwiki')
+  t.equal(obj.text, 'bonjour', 'text')
+  t.deepEqual(obj.wiki, { wiki: 'wiktionary', lang: 'fr' }, 'wiki')
+
   t.end()
 })
 


### PR DESCRIPTION
Resolves #378

There are still some edge cases (especially the ones where wiki vs language vs namespace is ambiguous) that are trickier to handle, but this is good to begin with.
