### PR TITLE
CLI Arguments Slice Optimization

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 var wtf = require('./src/index')
-var args = process.argv.slice(2, process.argv.length)
+var args = process.argv.slice(2)
 
 var modes = {
   '--json': 'json',


### PR DESCRIPTION
This is a small optimization in the `cli.js` script that removes the second argument in line 3. The `Array.prototype.slice()` method does not require a second argument. If it is left empty then it will use the array's length.