### PR TITLE
Added man page for wtf_wikipedia

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "git://github.com/spencermountain/wtf_wikipedia.git"
   },
+  "man": [
+    "./src/man/wtf_wikipedia.1"
+  ],
   "main": "builds/wtf_wikipedia.js",
   "module": "builds/wtf_wikipedia.mjs",
   "unpkg": "builds/wtf_wikipedia-client.min.js",

--- a/src/man/wtf_wikipedia.1
+++ b/src/man/wtf_wikipedia.1
@@ -1,0 +1,31 @@
+.Dd $wtf_wikipediadate$
+.TH wtf_wikipedia 1 "23 Aug 2020" "4.4.0" "wtf_wikipedia man page"
+.Dt wtf_wikipedia 1
+.Os
+.SH NAME
+wtf_wikipedia -- parse wikiscript into json
+.br
+wtf_wikipedia is a CLI written in nodejs that parses wikiscript into json
+.SH USAGE
+wtf_wikipedia
+.OP --json
+.OP --plaintext
+.[page]
+.SH DESCRIPTION
+A list of flags and their descriptions in wtf_wikipedia:
+.Bl -tag -width -indent
+.It --json
+Enter JSON mode, the wikiscript will be given in JSON
+.It --plaintext
+Enter plaintext mode in which results will be plaintext
+.It [page]
+Specify the page that has to be printed
+.El
+.Pp
+.SH EXIT CODES
+wtf_wikipedia exits with success unless the following happens:
+.Bl -tag -width -indent
+.It - A title is not provided
+.It - The fetch for the article failed
+.El
+.Pp


### PR DESCRIPTION
# 
# Overview
Added in a man page for `wtf_wikipedia`.
# List of Updates
Here is a list of updates
* Edited `package.json` to include an entry called `man` (`npm` automatically installs man pages inside the `man` entry)
* Created a file at `src/man/wtf_wikipedia`
* Added in a man page at `src/man/wtf_wikipedia`
# Testing
To test the layout, run:
```bash
git clone https://github.com/Yash-Singh1/wtf_wikipedia.git
cd wtf_wikipedia/src/man
man ./wtf_wikipedia.1
```
To test the changes, run:
```bash
git clone https://github.com/Yash-Singh1/wtf_wikipedia.git
cd wtf_wikipedia
sudo npm -g uninstall wtf_wikipedia ; npm link
```
Run `man wtf_wikipedia` and the manual page should appear.
To go back to the normal environment:
```bash
sudo npm -g uninstall wtf_wikipedia ; npm -g install wtf_wikipedia
```
***Note: The testing process will only work when the PR is open***
# 