### PR TITLE
Fixed links to builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,8 +678,8 @@ Please make a PR if you see something missing for your language.
 this library ships seperate client-side and server-side builds, to preserve filesize.
 
 - _[./wtf_wikipedia-client.js](./builds/wtf_wikipedia-client.js)_ - with sourcemap
-- _[./wtf_wikipedia-client.mjs](./builds/wtf_wikipedia-client.js)_ - as es-module (or Deno)
-- _[./wtf_wikipedia-client.min.js](./builds/wtf_wikipedia-client.js)_ - for production
+- _[./wtf_wikipedia-client.mjs](./builds/wtf_wikipedia-client.mjs)_ - as es-module (or Deno)
+- _[./wtf_wikipedia-client.min.js](./builds/wtf_wikipedia-client.min.js)_ - for production
 
 - _[./wtf_wikipedia.js](./builds/wtf_wikipedia.js)_ - main node build
 - _[./wtf_wikipedia.mjs](./builds/wtf_wikipedia.mjs)_ - esmodule node (deno/typescript)


### PR DESCRIPTION
Links to build files in readme weren't correct, simply fixed them.