### PR TITLE
Chage Section to use class

### DIFF
--- a/builds/types.d.ts
+++ b/builds/types.d.ts
@@ -1,0 +1,316 @@
+/**
+ * The constructor for the document class
+This function starts parsing the wiki text and sets the options in the class
+ * @param [wiki] - The wiki text
+ * @param [options] - The options for the parser
+ */
+declare class Document {
+    constructor(wiki?: string, options?: any);
+    /**
+     * Getter and setter for the tile.
+    If string is given then this function is a setter and sets the variable and returns the set value
+    If the string is not given then it will check if the title is available
+    If it is available it returns the title.
+    Else it will look if the first sentence contains a bolded phrase and assumes that's the title and returns it
+     * @param [str] - The title that will be set
+     * @returns The title found or given
+     */
+    title(str?: string): null | string;
+    /**
+     * If an pageID is given then it sets the pageID and returns the given pageID
+    Else if the pageID is already set it returns the pageID
+     * @param [id] - The pageID that will be set
+     * @returns The given or found pageID
+     */
+    pageID(id?: number): number | null;
+    /**
+     * If an WikidataID is given then it sets the WikidataID and returns the given WikidataID
+    Else if the WikidataID is already set it returns the WikidataID
+     * @param [id] - The WikidataID that will be set
+     * @returns The given or found WikidataID
+     */
+    wikidata(id?: string): string | null;
+    /**
+     * If an domain is given then it sets the domain and returns the given domain
+    Else if the domain is already set it returns the domain
+     * @param [str] - The domain that will be set
+     * @returns The given or found domain
+     */
+    domain(str?: string): string | null;
+    /**
+     * If an language is given then it sets the language and returns the given language
+    Else if the language is already set it returns the language
+     * @param [lang] - The language that will be set
+     * @returns The given or found language
+     */
+    language(lang?: string): string | null;
+    /**
+     * Gets the url of the page
+    If the language or domain is not available we substitute 'en' and 'wikipedia.org'
+    Then we use the template of `https://${lang}.${domain}/wiki/${title}` to make the url
+     * @returns The url of the page
+     */
+    url(): string | null;
+    /**
+     * If an namespace is given then it sets the namespace and returns the given namespace
+    Else if the namespace is already set it returns the namespace
+     * @param [ns] - The namespace that will be set
+     * @returns The given or found namespace
+     */
+    namespace(ns?: string): string | null;
+    /**
+     * Returns if the page is a redirect
+     * @returns Is the page a redirect
+     */
+    isRedirect(): boolean;
+    /**
+     * Returns information about the page this page redirects to
+     * @returns The redirected page
+     */
+    redirectTo(): null | any;
+    /**
+     * This function finds out if a page is a disambiguation page
+     * @returns Whether the page is a disambiguation page
+     */
+    isDisambiguation(): boolean;
+    /**
+     * If a clue is available return the category at that index
+    Else return all categories
+     * @param [clue] - The index of the wanted category
+     * @returns The category at the provided index or all categories
+     */
+    categories(clue?: number): string | string[];
+    /**
+     * Returns the 0th or clue-th category
+     * @param [clue] - The index of the wanted category
+     * @returns The category at the provided index
+     */
+    category(clue?: number): any | string | number;
+    /**
+     * returns the sections of the document
+    
+    If the clue is a string then it will return the section with that exact title
+    Else if the clue is a number then it returns the section at that index
+    Else it returns all the sections
+     * @param [clue] - A title of a section or a index of a wanted section
+     * @returns A section or a array of sections
+     */
+    sections(clue?: number | string): Section | Section[];
+    /**
+     * Returns the 0th or clue-th category
+     * @param [clue] - The index of the wanted section
+     * @returns The section at the provided index
+     */
+    section(clue?: number): Section;
+    /**
+     * Returns the paragraphs in the document
+    
+    If the clue is a number then it returns the paragraph at that index
+    Else it returns all paragraphs in an array
+     * @param [clue] - The index of the to be selected paragraph
+     * @returns the selected paragraph or an array of all paragraphs
+     */
+    paragraphs(clue?: number): Paragraph | Paragraph[];
+    /**
+     * returns the first or the clue-th paragraph
+     * @param [clue] - the index of the paragraph
+     * @returns The selected paragraph
+     */
+    paragraph(clue?: number): Paragraph;
+    /**
+     * if no clue is provided, it compiles an array of sentences in the wiki text.
+    if the clue is provided it return the sentence at the provided index
+     * @param clue - the index of the wanted sentence
+     * @returns an array of sentences or a single sentence
+     */
+    sentences(clue: number): Sentence[] | Sentence;
+    /**
+     * Returns the 0th or clue-th sentence
+     * @param [clue] - The index of the wanted sentence
+     * @returns The sentence at the provided index
+     */
+    sentence(clue?: number): Sentence;
+    /**
+     * This function search the whole page, including the infobox and image gallery templates for images
+    and then returns them in an array if no clue is provided.
+    if an clue is profieded then it returns the image at the clue-th index
+     * @param [clue] - the index of the image to be selected
+     * @returns a single image or an array of images
+     */
+    images(clue?: number): Image[] | Image;
+    /**
+     * Returns the 0th or clue-th image
+     * @param [clue] - The index of the wanted image
+     * @returns The image at the provided index
+     */
+    image(clue?: number): Image;
+    /**
+     * Return all links or if a clue is provided only the link at that index
+     * @param [clue] - the index of the wanted link
+     * @returns all the links or the selected link
+     */
+    links(clue?: number): string[] | string;
+    /**
+     * Returns the 0th or clue-th link
+     * @param [clue] - The index of the wanted link
+     * @returns The link at the provided index
+     */
+    link(clue?: number): any | string | number;
+    /**
+     * Return all inter wiki links or if a clue is provided only the inter wiki link at that index
+     * @param [clue] - the index of the wanted inter wiki link
+     * @returns all the inter wiki links or the selected inter wiki link
+     */
+    interwiki(clue?: number): string[] | string;
+    /**
+     * If a clue is available return the list at that index
+    Else return all lists
+     * @param [clue] - The index of the wanted list
+     * @returns The list at the provided index or all lists
+     */
+    lists(clue?: number): List | List[];
+    /**
+     * Returns the 0th or clue-th list
+     * @param [clue] - The index of the wanted list
+     * @returns The list at the provided index
+     */
+    list(clue?: number): any | string | number;
+    /**
+     * If a clue is available return the tables at that index
+    Else return all tables
+     * @param [clue] - The index of the wanted table
+     * @returns The table at the provided index or all tables
+     */
+    tables(clue?: number): Table | Tables[];
+    /**
+     * Returns the 0th or clue-th table
+     * @param [clue] - The index of the wanted table
+     * @returns The table at the provided index
+     */
+    table(clue?: number): any | string | number;
+    /**
+     * If a clue is available return the template at that index
+    Else return all templates
+     * @param [clue] - The index of the wanted template
+     * @returns The category at the provided index or all categories
+     */
+    templates(clue?: number): Template | Template[];
+    /**
+     * Returns the 0th or clue-th template
+     * @param [clue] - The index of the wanted template
+     * @returns The template at the provided index
+     */
+    template(clue?: number): any | string | number;
+    /**
+     * If a clue is available return the references at that index
+    Else return all references
+     * @param [clue] - The index of the wanted references
+     * @returns The category at the provided index or all references
+     */
+    references(clue?: number): Reference | Reference[];
+    /**
+     * Returns the 0th or clue-th reference
+     * @param [clue] - The index of the wanted reference
+     * @returns The reference at the provided index
+     */
+    reference(clue?: number): any | string | number;
+    /**
+     * Returns the 0th or clue-th citation
+     * @param [clue] - The index of the wanted citation
+     * @returns The citation at the provided index
+     */
+    citation(clue?: number): any | string | number;
+    /**
+     * finds and returns all coordinates
+    or if an clue is given, the coordinate at the index
+     * @param [clue] - the index of the coordinate returned
+     * @returns if a clue is given, the coordinate of null, else an array of coordinates
+     */
+    coordinates(clue?: number): object[] | any | null;
+    /**
+     * Returns the 0th or clue-th coordinate
+     * @param [clue] - The index of the wanted coordinate
+     * @returns The coordinate at the provided index
+     */
+    coordinate(clue?: number): any | string | number;
+    /**
+     * If clue is unidentified then it returns all infoboxes
+    If clue is a number then it returns the infobox at that index
+    It always sorts the infoboxes by size
+     * @param [clue] - the index of the infobox you want to select
+     * @returns the selected infobox or an array of infoboxes
+     */
+    infoboxes(clue?: number): Infobox | Infobox[];
+    /**
+     * Returns the 0th or clue-th infobox
+     * @param [clue] - The index of the wanted infobox
+     * @returns The infobox at the provided index
+     */
+    infobox(clue?: number): any | string | number;
+    /**
+     * return a plain text version of the wiki article
+     * @param [options] - the options for the parser
+     * @returns the plain text version of the article
+     */
+    text(options?: any): string;
+    /**
+     * return a json version of the Document class
+     * @param [options] - options for the rendering
+     * @returns this document as json
+     */
+    json(options?: any): any;
+    /**
+     * prints the title of every section
+     * @returns the document itself
+     */
+    debug(): Document;
+}
+
+/**
+ * the stuff between headings - 'History' section for example
+ * @param data - the data already gathered about the section
+ * @param doc - the document that this section belongs to
+ */
+declare class Section {
+    constructor(data: any, doc: Document);
+}
+
+/**
+ * returns one sentence object
+ * @param str - create a object from a sentence
+ * @returns the Sentence created from the text
+ */
+declare function fromText(str: string): Sentence;
+
+declare type fetchDefaults = {
+    path?: string | undefined;
+    wiki?: string | undefined;
+    domain?: string | undefined;
+    follow_redirects?: boolean | undefined;
+    lang?: string | undefined;
+    path?: string | undefined;
+    title?: string | number | (string | number)[] | undefined;
+    "Api-User-Agent"?: string | undefined;
+};
+
+declare const defaults: fetchDefaults;
+
+/**
+ * fetches the page from the wiki and returns a Promise with the parsed wikitext
+ * @param title - the title, PageID, URL or an array of all three of the page(s) you want to fetch
+ * @param [options] - the options for the fetch or the language of the wiki for the article or the callback if you dont provide any options
+ * @param [c] - the callback function for the call or the options for the fetch
+ */
+declare function fetch(title: string | number | (number | string)[], options?: fetchDefaults | ((...params: any[]) => any) | string, c?: ((...params: any[]) => any) | fetchDefaults): Promise<null | Document | Document[]>;
+
+declare type HeaderOptions = {
+    redirect: string;
+    method: string;
+};
+
+/**
+ * factory for header options
+ * @returns the generated options
+ */
+declare function makeHeaders(options: any): HeaderOptions;
+

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "lint": "eslint ./src/ ./plugins ./tests",
     "postinstall": "npm-recursive-install --rootDir=plugins",
     "start": "node ./scripts/demo.js",
+    "testSec": "nyc -r lcov -n 'src/02-section/*' tape tests/Section.test.js",
+    "testDoc": "nyc -r lcov -n 'src/02-section/*' tape tests/Document.test.js",
     "test": "cross-env TESTENV=dev && node ./scripts/test.js",
     "test:fetch": "cross-env TESTENV=dev && tape ./tests/fetch/*.test.js | tap-dancer",
     "test:spec": "cross-env TESTENV=dev && tape ./tests/fetch/*.test.js | tap-spec",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "node ./scripts/version.js && rollup -c",
     "build:all": "node ./scripts/buildAll.js",
-    "build:types": "jsdoc -t node_modules/tsd-jsdoc/dist -r ./src",
+    "build:types": "jsdoc -c ts-doc-config.json ./src",
     "coverage": "nyc -r lcov -n 'src/**/*' -n 'plugins/**/*' npm run coverage:tests",
     "coverage:tests": "npm run test && npm run test:fetch",
     "codecov": "npm run coverage && codecov -t 62d2cc94-1c1f-4e21-a9af-42cc0cf39c51",

--- a/plugins/html/src/02-section.js
+++ b/plugins/html/src/02-section.js
@@ -3,14 +3,15 @@ const defaults = {
   images: true,
   tables: true,
   lists: true,
-  paragraphs: true
+  paragraphs: true,
 }
-const doSection = function(options) {
+
+const doSection = function (options) {
   options = Object.assign({}, defaults, options)
   let html = ''
   //make the header
   if (options.headers === true && this.title()) {
-    let num = 1 + this.depth
+    let num = 1 + this.depth()
     html += '  <h' + num + '>' + this.title() + '</h' + num + '>'
     html += '\n'
   }
@@ -27,12 +28,13 @@ const doSection = function(options) {
       .map(t => t.html(options))
       .join('\n')
   }
-  // //make a html bullet-list
+  //make a html bullet-list
   if (options.lists === true) {
     html += this.lists()
       .map(list => list.html(options))
       .join('\n')
   }
+
   //finally, write the sentence text.
   if (options.paragraphs === true && this.paragraphs().length > 0) {
     html += '  <div class="text">\n'
@@ -56,4 +58,5 @@ const doSection = function(options) {
   }
   return '<div class="section">\n' + html + '</div>\n'
 }
+
 module.exports = doSection

--- a/plugins/latex/src/02-section.js
+++ b/plugins/latex/src/02-section.js
@@ -3,47 +3,49 @@ const defaults = {
   images: true,
   tables: true,
   lists: true,
-  paragraphs: true
+  paragraphs: true,
 }
 //map '==' depth to 'subsection', 'subsubsection', etc
-const doSection = function(options) {
+const doSection = function (options) {
   options = Object.assign({}, defaults, options)
   let out = ''
   let num = 1
+
   //make the header
   if (options.headers === true && this.title()) {
-    num = 1 + this.depth
+    num = 1 + this.depth()
     let vOpen = '\n'
     let vClose = '}'
     switch (num) {
-      case 1:
-        vOpen += '\\chapter{'
-        break
-      case 2:
-        vOpen += '\\section{'
-        break
-      case 3:
-        vOpen += '\\subsection{'
-        break
-      case 4:
-        vOpen += '\\subsubsection{'
-        break
-      case 5:
-        vOpen += '\\paragraph{'
-        vClose = '} \\\\ \n'
-        break
-      case 6:
-        vOpen += '\\subparagraph{'
-        vClose = '} \\\\ \n'
-        break
-      default:
-        vOpen +=
-          '\n% section with depth=' + num + ' undefined - use subparagraph instead\n\\subparagraph{'
-        vClose = '} \\\\ \n'
+    case 1:
+      vOpen += '\\chapter{'
+      break
+    case 2:
+      vOpen += '\\section{'
+      break
+    case 3:
+      vOpen += '\\subsection{'
+      break
+    case 4:
+      vOpen += '\\subsubsection{'
+      break
+    case 5:
+      vOpen += '\\paragraph{'
+      vClose = '} \\\\ \n'
+      break
+    case 6:
+      vOpen += '\\subparagraph{'
+      vClose = '} \\\\ \n'
+      break
+    default:
+      vOpen +=
+        '\n% section with depth=' + num + ' undefined - use subparagraph instead\n\\subparagraph{'
+      vClose = '} \\\\ \n'
     }
     out += vOpen + this.title() + vClose
     out += '\n'
   }
+
   //put any images under the header
   if (options.images === true && this.images()) {
     out += this.images()
@@ -51,18 +53,21 @@ const doSection = function(options) {
       .join('\n')
     //out += '\n';
   }
-  //make a out tablew
+
+  //make a out table
   if (options.tables === true && this.tables()) {
     out += this.tables()
       .map(t => t.latex(options))
       .join('\n')
   }
-  // //make a out bullet-list
+
+  //make a out bullet-list
   if (options.lists === true && this.lists()) {
     out += this.lists()
       .map(list => list.latex(options))
       .join('\n')
   }
+
   //finally, write the sentence text.
   if (options.paragraphs === true || options.sentences === true) {
     out += this.paragraphs()
@@ -70,8 +75,9 @@ const doSection = function(options) {
       .join(' ')
     out += '\n'
   }
-  // let title_tag = ' SECTION depth=' + num + ' - TITLE: ' + section.title + '\n';
-  // wrap a section comment
+
+  //let title_tag = ' SECTION depth=' + num + ' - TITLE: ' + section.title + '\n';
+  //wrap a section comment
   //out = '\n% BEGIN' + title_tag + out + '\n% END' + title_tag;
   return out
 }

--- a/plugins/markdown/src/02-section.js
+++ b/plugins/markdown/src/02-section.js
@@ -3,20 +3,22 @@ const defaults = {
   images: true,
   tables: true,
   lists: true,
-  paragraphs: true
+  paragraphs: true,
 }
 
-const doSection = function(options) {
+const doSection = function (options) {
   options = Object.assign({}, defaults, options)
   let md = ''
+
   //make the header
   if (options.headers === true && this.title()) {
     let header = '##'
-    for (let i = 0; i < this.depth; i += 1) {
+    for (let i = 0; i < this.depth(); i += 1) {
       header += '#'
     }
     md += header + ' ' + this.title() + '\n'
   }
+
   //put any images under the header
   if (options.images === true) {
     let images = this.images()
@@ -25,7 +27,8 @@ const doSection = function(options) {
       md += '\n'
     }
   }
-  //make a mardown table
+
+  //make a markdown table
   if (options.tables === true) {
     let tables = this.tables()
     if (tables.length > 0) {
@@ -34,7 +37,8 @@ const doSection = function(options) {
       md += '\n'
     }
   }
-  //make a mardown bullet-list
+
+  //make a markdown bullet-list
   if (options.lists === true) {
     let lists = this.lists()
     if (lists.length > 0) {
@@ -42,6 +46,7 @@ const doSection = function(options) {
       md += '\n'
     }
   }
+
   //finally, write the sentence text.
   if (options.paragraphs === true || options.sentences === true) {
     md += this.paragraphs()
@@ -53,6 +58,7 @@ const doSection = function(options) {
       })
       .join('\n\n')
   }
+
   return md
 }
 module.exports = doSection

--- a/src/01-document/Document.js
+++ b/src/01-document/Document.js
@@ -667,7 +667,7 @@ class Document {
     console.log('\n')
     this.sections().forEach((sec) => {
       let indent = ' - '
-      for (let i = 0; i < sec.depth; i += 1) {
+      for (let i = 0; i < sec.depth(); i += 1) {
         indent = ' -' + indent
       }
       console.log(indent + (sec.title() || '(Intro)'))

--- a/src/01-document/Document.js
+++ b/src/01-document/Document.js
@@ -307,7 +307,7 @@ class Document {
    */
   sections(clue) {
     let arr = this._sections || []
-    arr.forEach((sec) => (sec.doc = this))
+    arr.forEach((sec) => (sec._doc = this))
 
     //grab a specific section, by its title
     if (typeof clue === 'string') {
@@ -369,7 +369,7 @@ class Document {
   }
 
   /**
-   * if no clue is provided, it compile an array of sentences in the wiki text.
+   * if no clue is provided, it compiles an array of sentences in the wiki text.
    * if the clue is provided it return the sentence at the provided index
    *
    * @param {number} clue the index of the wanted sentence
@@ -574,7 +574,7 @@ class Document {
 
   /**
    * finds and returns all coordinates
-   * or if an clue is given, the coordinate ot the index
+   * or if an clue is given, the coordinate at the index
    *
    * @param {number} [clue] the index of the coordinate returned
    * @returns {object[]|object|null} if a clue is given, the coordinate of null, else an array of coordinates

--- a/src/01-document/Document.js
+++ b/src/01-document/Document.js
@@ -2,23 +2,14 @@ const sectionMap = require('./_sectionMap')
 const toJSON = require('./toJson')
 const disambig = require('./disambig')
 const setDefaults = require('../_lib/setDefaults')
+const {isArray} = require('../_lib/helpers')
+
 const Image = require('../image/Image')
 const redirects = require('./redirects')
 const preProcess = require('./preProcess')
 const parse = {
   section: require('../02-section'),
   categories: require('./categories'),
-}
-
-/**
- * determines if an variable is an array or not
- *
- * @private
- * @param {*} arr the variable that needs judgment
- * @returns {boolean} whether the variable is an array
- */
-const isArray = function (arr) {
-  return Object.prototype.toString.call(arr) === '[object Array]'
 }
 
 /**

--- a/src/01-document/_sectionMap.js
+++ b/src/01-document/_sectionMap.js
@@ -5,7 +5,7 @@
  * @param {Document} doc the document with the sections
  * @param {string} fn the function name of the function that will be called
  * @param {string | number} [clue] the clue that will be used with the function
- * @returns {*[]|*} the array of item at the index of the clue
+ * @returns {Array|*} the array of item at the index of the clue
  */
 const sectionMap = function (doc, fn, clue) {
   let arr = []

--- a/src/02-section/Section.js
+++ b/src/02-section/Section.js
@@ -75,8 +75,12 @@ class Section {
     return index
   }
 
-  indentation() {
+  depth(){
     return this._depth
+  }
+
+  indentation() {
+    return this.depth()
   }
 
   sentences(n) {
@@ -261,11 +265,11 @@ class Section {
     for (let i = index + 1; i < sections.length; i++) {
       //if the depth is smaller then the current depth then there is no next sibling
       //aka the depth of the section at position i a level higher then this section then this section is the last section at this depth
-      if (sections[i]._depth < this._depth) {
+      if (sections[i].depth() < this.depth()) {
         return null
       }
       //if the section has the same depth as the current section then it is the next sibling
-      if (sections[i]._depth === this._depth) {
+      if (sections[i].depth() === this.depth()) {
         return sections[i]
       }
     }
@@ -307,9 +311,9 @@ class Section {
     let index = this.index()
     let children = []
     //(immediately preceding sections with higher depth)
-    if (sections[index + 1] && sections[index + 1]._depth > this._depth) {
+    if (sections[index + 1] && sections[index + 1].depth() > this.depth()) {
       for (let i = index + 1; i < sections.length; i += 1) {
-        if (sections[i]._depth > this._depth) {
+        if (sections[i].depth() > this.depth()) {
           children.push(sections[i])
         } else {
           break
@@ -337,7 +341,7 @@ class Section {
     let sections = this._doc.sections()
     let index = this.index()
     for (let i = index; i >= 0; i -= 1) {
-      if (sections[i] && sections[i]._depth < this._depth) {
+      if (sections[i] && sections[i].depth() < this.depth()) {
         return sections[i]
       }
     }

--- a/src/02-section/Section.js
+++ b/src/02-section/Section.js
@@ -1,5 +1,16 @@
+//@ts-expect-error because this is some kind of type definition for jsdoc that's why typescript does not recognize it
+const Document = require('../01-document/Document')
 const toJSON = require('./toJson')
 const setDefaults = require('../_lib/setDefaults')
+
+const parse = {
+  heading: require('./heading'),
+  table: require('../table'),
+  paragraphs: require('../03-paragraph'),
+  templates: require('../template'),
+  references: require('../reference'),
+  startEndTemplates: require('./start-to-end'),
+}
 
 const defaults = {
   tables: true,
@@ -9,40 +20,66 @@ const defaults = {
   infoboxes: true,
 }
 
-//the stuff between headings - 'History' section for example
-const Section = function (data) {
-  this.depth = data.depth
-  this.doc = null
-  this._title = data.title || ''
-  Object.defineProperty(this, 'doc', {
-    enumerable: false,
-    value: null,
-  })
-  data.templates = data.templates || []
-  Object.defineProperty(this, 'data', {
-    enumerable: false,
-    value: data,
-  })
-}
+/**
+ * @class
+ */
+class Section {
+  /**
+   * the stuff between headings - 'History' section for example
+   *
+   * @param {Object} data the data already gathered about the section
+   * @param {Document} doc the document that this section belongs to
+   */
+  constructor(data, doc) {
+    this._doc = doc || null
 
-const methods = {
-  title: function () {
+
+    this._title = data.title || ''
+    this._depth = data.depth
+    this._wiki = data.wiki || ''
+    this._templates = []
+    this._tables = []
+    this._infoboxes = []
+    this._references = []
+    this._paragraphs = []
+
+    //parse-out <template></template>' and {{start}}...{{end}} templates
+    const startEndTemplates = parse.startEndTemplates(this, doc)
+    this._wiki = startEndTemplates.text
+    this._templates = [...this._templates, ...startEndTemplates.templates]
+
+    //parse-out the <ref></ref> tags
+    parse.references(this)
+    //parse-out all {{templates}}
+    parse.templates(this, doc)
+
+    //parse the tables
+    parse.table(this)
+
+    //now parse all double-newlines
+    parse.paragraphs(this, doc)
+  }
+
+  title() {
     return this._title || ''
-  },
-  index: function () {
-    if (!this.doc) {
+  }
+
+  index() {
+    if (!this._doc) {
       return null
     }
-    let index = this.doc.sections().indexOf(this)
+    let index = this._doc.sections().indexOf(this)
     if (index === -1) {
       return null
     }
     return index
-  },
-  indentation: function () {
-    return this.depth
-  },
-  sentences: function (n) {
+  }
+
+  indentation() {
+    return this._depth
+  }
+
+  sentences(n) {
     let arr = this.paragraphs().reduce((list, p) => {
       return list.concat(p.sentences())
     }, [])
@@ -50,54 +87,73 @@ const methods = {
       return arr[n]
     }
     return arr || []
-  },
-  paragraphs: function (n) {
-    let arr = this.data.paragraphs || []
+  }
+
+  paragraphs(n) {
+    let arr = this._paragraphs || []
     if (typeof n === 'number') {
       return arr[n]
     }
     return arr || []
-  },
-  paragraph: function (n) {
-    let arr = this.data.paragraphs || []
+  }
+
+  paragraph(n) {
+    let arr = this._paragraphs || []
     if (typeof n === 'number') {
       return arr[n]
     }
     return arr[0]
-  },
-  links: function (n) {
+  }
+
+  links(n) {
     let arr = []
+
     this.infoboxes().forEach(templ => {
-      templ.links(n).forEach(link => arr.push(link))
+      arr.push(templ.links())
     })
+
     this.sentences().forEach(s => {
-      s.links(n).forEach(link => arr.push(link))
+      arr.push(s.links())
     })
+
     this.tables().forEach(t => {
-      t.links(n).forEach(link => arr.push(link))
+      arr.push(t.links())
     })
+
     this.lists().forEach(list => {
-      list.links(n).forEach(link => arr.push(link))
+      arr.push(list.links())
     })
+
+    arr = arr
+      .reduce((acc, val) => acc.concat(val), []) //flatten the array
+      .filter((val) => val !== undefined) //filter out all the undefined from the flattened empty arrays
+
     if (typeof n === 'number') {
       return arr[n]
-    } else if (typeof n === 'string') {
-      //grab a link like .links('Fortnight')
-      n = n.charAt(0).toUpperCase() + n.substring(1) //titlecase it
-      let link = arr.find(o => o.page() === n)
+    }
+
+    if (typeof n === 'string') {
+
+      n = n.toLowerCase()
+
+      let link = arr.find(o => o.page().toLowerCase() === n)
+
       return link === undefined ? [] : [link]
     }
+
     return arr
-  },
-  tables: function (clue) {
-    let arr = this.data.tables || []
+  }
+
+  tables(clue) {
+    let arr = this._tables || []
     if (typeof clue === 'number') {
       return arr[clue]
     }
     return arr
-  },
-  templates: function (clue) {
-    let arr = this.data.templates || []
+  }
+
+  templates(clue) {
+    let arr = this._templates || []
     arr = arr.map(t => t.json())
     if (typeof clue === 'number') {
       return arr[clue]
@@ -107,16 +163,18 @@ const methods = {
       return arr.filter(o => o.template === clue || o.name === clue)
     }
     return arr
-  },
-  infoboxes: function (clue) {
-    let arr = this.data.infoboxes || []
+  }
+
+  infoboxes(clue) {
+    let arr = this._infoboxes || []
     if (typeof clue === 'number') {
       return arr[clue]
     }
     return arr
-  },
-  coordinates: function (clue) {
-    let arr = [].concat(this.templates('coord'), this.templates('coor'))
+  }
+
+  coordinates(clue) {
+    let arr = [...this.templates('coord'), ...this.templates('coor')]
     if (typeof clue === 'number') {
       if (!arr[clue]) {
         return []
@@ -124,8 +182,9 @@ const methods = {
       return arr[clue]
     }
     return arr
-  },
-  lists: function (clue) {
+  }
+
+  lists(clue) {
     let arr = []
     this.paragraphs().forEach(p => {
       arr = arr.concat(p.lists())
@@ -134,7 +193,8 @@ const methods = {
       return arr[clue]
     }
     return arr
-  },
+  }
+
   interwiki(num) {
     let arr = []
     this.paragraphs().forEach(p => {
@@ -144,8 +204,9 @@ const methods = {
       return arr[num]
     }
     return arr || []
-  },
-  images: function (clue) {
+  }
+
+  images(clue) {
     let arr = []
     this.paragraphs().forEach(p => {
       arr = arr.concat(p.images())
@@ -154,67 +215,101 @@ const methods = {
       return arr[clue]
     }
     return arr || []
-  },
-  references: function (clue) {
-    let arr = this.data.references || []
+  }
+
+  references(clue) {
+    let arr = this._references || []
     if (typeof clue === 'number') {
       return arr[clue]
     }
     return arr
-  },
+  }
+
+  citations(clue) {
+    return this.references(clue)
+  }
 
   //transformations
-  remove: function () {
-    if (!this.doc) {
+  remove() {
+    if (!this._doc) {
       return null
     }
     let bads = {}
     bads[this.title()] = true
     //remove children too
     this.children().forEach(sec => (bads[sec.title()] = true))
-    let sections = this.doc.sections()
+    let sections = this._doc.sections()
     sections = sections.filter(sec => bads.hasOwnProperty(sec.title()) !== true)
-    this.doc._sections = sections
-    return this.doc
-  },
+    this._doc._sections = sections
+    return this._doc
+  }
 
   //move-around sections like in jquery
-  nextSibling: function () {
-    if (!this.doc) {
+  nextSibling() {
+    //if this section is not part of a document then we can go to the next part of the document
+    if (!this._doc) {
       return null
     }
-    let sections = this.doc.sections()
+
+    //first we get the a list of sections and our own position in this list
+    let sections = this._doc.sections()
     let index = this.index()
-    for (let i = index + 1; i < sections.length; i += 1) {
-      if (sections[i].depth < this.depth) {
+
+    //then we look trough the list looking for the next sibling
+    //aka we look the next item at the same depth as us
+    //so we start the loop at the next section in the list and go till the length of the list
+    for (let i = index + 1; i < sections.length; i++) {
+      //if the depth is smaller then the current depth then there is no next sibling
+      //aka the depth of the section at position i a level higher then this section then this section is the last section at this depth
+      if (sections[i]._depth < this._depth) {
         return null
       }
-      if (sections[i].depth === this.depth) {
+      //if the section has the same depth as the current section then it is the next sibling
+      if (sections[i]._depth === this._depth) {
         return sections[i]
       }
     }
+    //if the loop has no results then there is no next sibling and we are at the end of the file
     return null
-  },
-  lastSibling: function () {
-    if (!this.doc) {
+  }
+
+  next() {
+    return this.nextSibling()
+  }
+
+  lastSibling() {
+    if (!this._doc) {
       return null
     }
-    let sections = this.doc.sections()
+    let sections = this._doc.sections()
     let index = this.index()
     return sections[index - 1] || null
-  },
-  children: function (n) {
-    if (!this.doc) {
+  }
+
+  last() {
+    return this.lastSibling()
+  }
+
+  previousSibling() {
+    return this.lastSibling()
+  }
+
+  previous() {
+    return this.lastSibling()
+  }
+
+  children(n) {
+    if (!this._doc) {
       return null
     }
 
-    let sections = this.doc.sections()
+    let sections = this._doc.sections()
     let index = this.index()
     let children = []
     //(immediately preceding sections with higher depth)
-    if (sections[index + 1] && sections[index + 1].depth > this.depth) {
+    if (sections[index + 1] && sections[index + 1]._depth > this._depth) {
       for (let i = index + 1; i < sections.length; i += 1) {
-        if (sections[i].depth > this.depth) {
+        if (sections[i]._depth > this._depth) {
           children.push(sections[i])
         } else {
           break
@@ -229,40 +324,46 @@ const methods = {
       return children[n]
     }
     return children
-  },
-  parent: function () {
-    if (!this.doc) {
+  }
+
+  sections(n) {
+    return this.children(n)
+  }
+
+  parent() {
+    if (!this._doc) {
       return null
     }
-    let sections = this.doc.sections()
+    let sections = this._doc.sections()
     let index = this.index()
     for (let i = index; i >= 0; i -= 1) {
-      if (sections[i] && sections[i].depth < this.depth) {
+      if (sections[i] && sections[i]._depth < this._depth) {
         return sections[i]
       }
     }
     return null
-  },
-  text: function (options) {
+  }
+
+  text(options) {
     options = setDefaults(options, defaults)
     let pList = this.paragraphs()
     pList = pList.map(p => p.text(options))
     return pList.join('\n\n')
-  },
-  json: function (options) {
+  }
+
+  json(options) {
     options = setDefaults(options, defaults)
     return toJSON(this, options)
-  },
+  }
+
+  toJSON() {
+    return Object.entries(this)
+      .filter((entry) => entry[0] !== '_doc')
+      .reduce((accum, [k, v]) => {
+        accum[k] = v
+        return accum
+      }, {})
+  }
 }
-//aliases
-methods.next = methods.nextSibling
-methods.last = methods.lastSibling
-methods.previousSibling = methods.lastSibling
-methods.previous = methods.lastSibling
-methods.citations = methods.references
-methods.sections = methods.children
-Object.keys(methods).forEach(k => {
-  Section.prototype[k] = methods[k]
-})
 
 module.exports = Section

--- a/src/02-section/heading.js
+++ b/src/02-section/heading.js
@@ -19,9 +19,9 @@ const parseHeading = function (section, str) {
   title = title.replace(/\{\{.+?\}\}/, '')
 
   //same for references (i know..)
-  let obj = { wiki: title }
+  let obj = {_wiki: title}
   parseReferences(obj)
-  title = obj.wiki
+  title = obj._wiki
 
   //trim leading/trailing whitespace
   title = trim_whitespace(title)

--- a/src/02-section/heading.js
+++ b/src/02-section/heading.js
@@ -1,10 +1,10 @@
-const fns = require('../_lib/helpers')
+const {trim_whitespace} = require('../_lib/helpers')
 const parseSentence = require('../04-sentence/').fromText
 const parseReferences = require('../reference/')
 const heading_reg = /^(={1,5})(.{1,200}?)={1,5}$/
 
 //interpret depth, title of headings like '==See also=='
-const parseHeading = function(section, str) {
+const parseHeading = function (section, str) {
   let m = str.match(heading_reg)
   if (!m) {
     section.title = ''
@@ -13,21 +13,26 @@ const parseHeading = function(section, str) {
   }
   let title = m[2] || ''
   title = parseSentence(title).text()
+
   //amazingly, you can see inline {{templates}} in this text, too
   //... let's not think about that now.
   title = title.replace(/\{\{.+?\}\}/, '')
+
   //same for references (i know..)
   let obj = { wiki: title }
   parseReferences(obj)
   title = obj.wiki
+
   //trim leading/trailing whitespace
-  title = fns.trim_whitespace(title)
+  title = trim_whitespace(title)
   let depth = 0
   if (m[1]) {
     depth = m[1].length - 2
   }
+
   section.title = title
   section.depth = depth
   return section
 }
+
 module.exports = parseHeading

--- a/src/02-section/index.js
+++ b/src/02-section/index.js
@@ -21,8 +21,8 @@ const removeReferenceSection = function (sections) {
       }
 
       //what it has children? awkward
-      if (sections[i + 1] && sections[i + 1].depth > s.depth) {
-        sections[i + 1].depth -= 1 //move it up a level?...
+      if (sections[i + 1] && sections[i + 1].depth() > s.depth()) {
+        sections[i + 1]._depth -= 1 //move it up a level?...
       }
       return false
     }

--- a/src/02-section/index.js
+++ b/src/02-section/index.js
@@ -6,25 +6,6 @@ const section_reg = /(?:\n|^)(={2,5}.{1,200}?={2,5})/g
 //interpret ==heading== lines
 const parse = {
   heading: require('./heading'),
-  table: require('../table'),
-  paragraphs: require('../03-paragraph'),
-  templates: require('../template'),
-  references: require('../reference'),
-  startEndTemplates: require('./start-to-end'),
-}
-
-const oneSection = function (section, doc) {
-  parse.startEndTemplates(section, doc)
-  //parse-out the <ref></ref> tags
-  parse.references(section)
-  //parse-out all {{templates}}
-  parse.templates(section, doc)
-  //parse the tables
-  parse.table(section)
-  //now parse all double-newlines
-  parse.paragraphs(section, doc)
-  section = new Section(section)
-  return section
 }
 
 const removeReferenceSection = function (sections) {
@@ -33,10 +14,12 @@ const removeReferenceSection = function (sections) {
       if (s.paragraphs().length > 0) {
         return true
       }
+
       //does it have some wacky templates?
       if (s.templates().length > 0) {
         return true
       }
+
       //what it has children? awkward
       if (sections[i + 1] && sections[i + 1].depth > s.depth) {
         sections[i + 1].depth -= 1 //move it up a level?...
@@ -49,29 +32,29 @@ const removeReferenceSection = function (sections) {
 
 const parseSections = function (doc) {
   let sections = []
-  let split = doc._wiki.split(section_reg)
-  for (let i = 0; i < split.length; i += 2) {
-    let heading = split[i - 1] || ''
-    let wiki = split[i] || ''
+  let splits = doc._wiki.split(section_reg)
+
+  for (let i = 0; i < splits.length; i += 2) {
+    let heading = splits[i - 1] || ''
+    let wiki = splits[i] || ''
+
     if (wiki === '' && heading === '') {
       //usually an empty 'intro' section
       continue
     }
-    let section = {
+
+    let data = {
       title: '',
       depth: null,
       wiki: wiki,
-      templates: [],
-      tables: [],
-      infoboxes: [],
-      references: [],
     }
-    //figure-out title/depth
-    parse.heading(section, heading)
-    //parse it up
-    let s = oneSection(section, doc)
-    sections.push(s)
+
+    //figure-out title and depth
+    parse.heading(data, heading)
+
+    sections.push(new Section(data, doc))
   }
+
   //remove empty references section
   return removeReferenceSection(sections)
 }

--- a/src/02-section/start-to-end/election.js
+++ b/src/02-section/start-to-end/election.js
@@ -1,31 +1,43 @@
 const parseTemplates = require('../../template')
-//this is a non-traditional template, for some reason
-//https://en.wikipedia.org/wiki/Template:Election_box
-const parseElection = function(section) {
-  let wiki = section.wiki
-  wiki = wiki.replace(/\{\{election box begin([\s\S]+?)\{\{election box end\}\}/gi, tmpl => {
+
+/**
+ * parses out the `Election_box` template from the wiki text
+ *
+ * this is a non-traditional template, for some reason
+ * https://en.wikipedia.org/wiki/Template:Election_box
+ *
+ * @private
+ * @param {Catcher} catcher an object to provide and catch data
+ */
+const parseElection = function (catcher) {
+  catcher.text = catcher.text.replace(/\{\{election box begin([\s\S]+?)\{\{election box end\}\}/gi, tmpl => {
     let data = {
-      wiki: tmpl,
-      templates: []
+      _wiki: tmpl,
+      _templates: [],
     }
+
     //put it through our full template parser..
     parseTemplates(data)
+
     //okay, pull it apart into something sensible..
-    let templates = data.templates.map(t => t.json())
+    let templates = data._templates.map(t => t.json())
+
     let start = templates.find(t => t.template === 'election box') || {}
     let candidates = templates.filter(t => t.template === 'election box candidate')
     let summary = templates.find(t => t.template === 'election box gain' || t.template === 'election box hold') || {}
+
     if (candidates.length > 0 || summary) {
-      section.templates.push({
+      catcher.templates.push({
         template: 'election box',
         title: start.title,
         candidates: candidates,
-        summary: summary.data
+        summary: summary.data,
       })
     }
-    //remove it all
+
+    //return empty string to remove the template from the wiki text
     return ''
   })
-  section.wiki = wiki
 }
+
 module.exports = parseElection

--- a/src/02-section/start-to-end/gallery.js
+++ b/src/02-section/start-to-end/gallery.js
@@ -1,20 +1,31 @@
+//@ts-expect-error because this is some kind of type definition for jsdoc that's why typescript does not recognize it
+const Document = require('../../01-document/Document')
+const Section = require('../Section')
+
 const parseSentence = require('../../04-sentence/').fromText
 const Image = require('../../image/Image')
 //okay, <gallery> is a xml-tag, with newline-separated data, somehow pivoted by '|'...
 //all deities help us. truly -> https://en.wikipedia.org/wiki/Help:Gallery_tag
 //- not to be confused with https://en.wikipedia.org/wiki/Template:Gallery...
-const parseGallery = function (section, doc) {
-  let wiki = section.wiki
-  wiki = wiki.replace(/<gallery([^>]*?)>([\s\S]+?)<\/gallery>/g, (_, attrs, inside) => {
+/**
+ *
+ * @private
+ * @param {Catcher} catcher
+ * @param {Document} doc
+ * @param {Section} section
+ */
+const parseGallery = function (catcher, doc, section) {
+  catcher.text = catcher.text.replace(/<gallery([^>]*?)>([\s\S]+?)<\/gallery>/g, (_, attrs, inside) => {
     let images = inside.split(/\n/g)
     images = images.filter((str) => str && str.trim() !== '')
+
     //parse the line, which has an image and sometimes a caption
     images = images.map((str) => {
       let arr = str.split(/\|/)
       let obj = {
         file: arr[0].trim(),
-        lang: doc._lang,
-        domain: doc._domain,
+        lang: doc.lang(),
+        domain: doc.domain(),
       }
       let img = new Image(obj).json()
       let caption = arr.slice(1).join('|')
@@ -23,16 +34,18 @@ const parseGallery = function (section, doc) {
       }
       return img
     })
+
     //add it to our templates list
     if (images.length > 0) {
-      section.templates.push({
+      catcher.templates.push({
         template: 'gallery',
         images: images,
         pos: section.title,
       })
     }
+
+    //return empty string to remove the template from the wiki text
     return ''
   })
-  section.wiki = wiki
 }
 module.exports = parseGallery

--- a/src/02-section/start-to-end/index.js
+++ b/src/02-section/start-to-end/index.js
@@ -1,19 +1,50 @@
+//@ts-expect-error because this is some kind of type definition for jsdoc that's why typescript does not recognize it
+const Document = require('../../01-document/Document')
+const Section = require('../Section')
+
 const parseGallery = require('./gallery')
 const parseElection = require('./election')
 const parseNBA = require('./nba')
 const parseMlb = require('./mlb')
 const parseMMA = require('./mma')
 const parseMath = require('./math')
-// Most templates are '{{template}}', but then, some are '<template></template>'.
-// ... others are {{start}}...{{end}}
-// -> these are those ones.
-const xmlTemplates = function (section, doc) {
-  parseElection(section)
-  parseGallery(section, doc)
-  parseMath(section)
-  parseMlb(section)
-  parseMMA(section)
-  parseNBA(section)
+
+
+/**
+ * a catcher for the data used in these parsers
+ *
+ * @private
+ * @typedef Catcher
+ * @property {Template[]} templates the found templates
+ * @property {string} text the wiki text
+ */
+
+/**
+ * parses out non standard templates
+ *
+ * Most templates are '{{template}}',
+ * but then, some are '<template></template>' others are {{start}}...{{end}}
+ * -> the templates here are of the second type.
+ *
+ * @private
+ * @param {Section} section
+ * @param {Document} doc
+ * @return {Catcher}
+ */
+const xmlTemplates = function ( section, doc) {
+  const catcher = {
+    templates: [],
+    text: section._wiki
+  }
+
+  parseElection(catcher)
+  parseGallery(catcher, doc, section)
+  parseMath(catcher)
+  parseMlb(catcher)
+  parseMMA(catcher)
+  parseNBA(catcher)
+
+  return catcher
 }
 
 module.exports = xmlTemplates

--- a/src/02-section/start-to-end/math.js
+++ b/src/02-section/start-to-end/math.js
@@ -1,30 +1,43 @@
 const parseSentence = require('../../04-sentence/').fromText
-//xml <math>y=mx+b</math> support
-//https://en.wikipedia.org/wiki/Help:Displaying_a_formula
-const parseMath = function(section) {
-  let wiki = section.wiki
-  wiki = wiki.replace(/<math([^>]*?)>([\s\S]+?)<\/math>/g, (_, attrs, inside) => {
+
+/**
+ * try to parse out the math and chem templates
+ *
+ * xml <math>y=mx+b</math> support
+ * https://en.wikipedia.org/wiki/Help:Displaying_a_formula
+ *
+ * @private
+ * @param {Catcher} catcher
+ */
+const parseMath = function (catcher) {
+  catcher.text = catcher.text.replace(/<math([^>]*?)>([\s\S]+?)<\/math>/g, (_, attrs, inside) => {
     //clean it up a little?
     let formula = parseSentence(inside).text()
-    section.templates.push({
+
+    catcher.templates.push({
       template: 'math',
       formula: formula,
-      raw: inside
+      raw: inside,
     })
-    //should we atleast try to render it in plaintext? :/
+
+    //should we at least try to render it in plaintext? :/
     if (formula && formula.length < 12) {
       return formula
     }
+
+    //return empty string to remove the template from the wiki text
     return ''
   })
+
   //try chemistry version too
-  wiki = wiki.replace(/<chem([^>]*?)>([\s\S]+?)<\/chem>/g, (_, attrs, inside) => {
-    section.templates.push({
+  catcher.text = catcher.text.replace(/<chem([^>]*?)>([\s\S]+?)<\/chem>/g, (_, attrs, inside) => {
+    catcher.templates.push({
       template: 'chem',
-      data: inside
+      data: inside,
     })
+
+    //return empty string to remove the template from the wiki text
     return ''
   })
-  section.wiki = wiki
 }
 module.exports = parseMath

--- a/src/02-section/start-to-end/mlb.js
+++ b/src/02-section/start-to-end/mlb.js
@@ -2,7 +2,7 @@ const tableParser = require('../../table/parse')
 //https://en.wikipedia.org/wiki/Template:MLB_game_log_section
 
 //this is pretty nuts
-const whichHeadings = function(tmpl) {
+const whichHeadings = function (tmpl) {
   let headings = ['#', 'date', 'opponent', 'score', 'win', 'loss', 'save', 'attendance', 'record']
   if (/\|stadium=y/i.test(tmpl) === true) {
     headings.splice(7, 0, 'stadium') //save, stadium, attendance
@@ -15,13 +15,18 @@ const whichHeadings = function(tmpl) {
   }
   return headings
 }
-
-const parseMlb = function(section) {
-  let wiki = section.wiki
-  wiki = wiki.replace(/\{\{mlb game log (section|month)[\s\S]+?\{\{mlb game log (section|month) end\}\}/gi, tmpl => {
+/**
+ *
+ * @private
+ * @param {Catcher} catcher
+ */
+const parseMlb = function (catcher) {
+  catcher.text = catcher.text.replace(/\{\{mlb game log (section|month)[\s\S]+?\{\{mlb game log (section|month) end\}\}/gi, tmpl => {
     let headings = whichHeadings(tmpl)
+
     tmpl = tmpl.replace(/^\{\{.*?\}\}/, '')
     tmpl = tmpl.replace(/\{\{mlb game log (section|month) end\}\}/i, '')
+
     let headers = '! ' + headings.join(' !! ')
     let table = '{|\n' + headers + '\n' + tmpl + '\n|}'
     let rows = tableParser(table)
@@ -31,12 +36,14 @@ const parseMlb = function(section) {
       })
       return row
     })
-    section.templates.push({
+
+    catcher.templates.push({
       template: 'mlb game log section',
-      data: rows
+      data: rows,
     })
+
+    //return empty string to remove the template from the wiki text
     return ''
   })
-  section.wiki = wiki
 }
 module.exports = parseMlb

--- a/src/02-section/start-to-end/mma.js
+++ b/src/02-section/start-to-end/mma.js
@@ -1,12 +1,18 @@
 const tableParser = require('../../table/parse')
 let headings = ['res', 'record', 'opponent', 'method', 'event', 'date', 'round', 'time', 'location', 'notes']
 
-//https://en.wikipedia.org/wiki/Template:MMA_record_start
-const parseMMA = function(section) {
-  let wiki = section.wiki
-  wiki = wiki.replace(/\{\{mma record start[\s\S]+?\{\{end\}\}/gi, tmpl => {
+/**
+ *
+ * https://en.wikipedia.org/wiki/Template:MMA_record_start
+ *
+ * @private
+ * @param {Catcher} catcher
+ */
+const parseMMA = function (catcher) {
+  catcher.text = catcher.text.replace(/\{\{mma record start[\s\S]+?\{\{end\}\}/gi, tmpl => {
     tmpl = tmpl.replace(/^\{\{.*?\}\}/, '')
     tmpl = tmpl.replace(/\{\{end\}\}/i, '')
+
     let headers = '! ' + headings.join(' !! ')
     let table = '{|\n' + headers + '\n' + tmpl + '\n|}'
     let rows = tableParser(table)
@@ -16,12 +22,14 @@ const parseMMA = function(section) {
       })
       return row
     })
-    section.templates.push({
+
+    catcher.templates.push({
       template: 'mma record start',
-      data: rows
+      data: rows,
     })
+
+    //return empty string to remove the template from the wiki text
     return ''
   })
-  section.wiki = wiki
 }
 module.exports = parseMMA

--- a/src/02-section/start-to-end/nba.js
+++ b/src/02-section/start-to-end/nba.js
@@ -2,32 +2,38 @@ const tableParser = require('../../table/parse')
 const keys = {
   coach: ['team', 'year', 'g', 'w', 'l', 'w-l%', 'finish', 'pg', 'pw', 'pl', 'pw-l%'],
   player: ['year', 'team', 'gp', 'gs', 'mpg', 'fg%', '3p%', 'ft%', 'rpg', 'apg', 'spg', 'bpg', 'ppg'],
-  roster: ['player', 'gp', 'gs', 'mpg', 'fg%', '3fg%', 'ft%', 'rpg', 'apg', 'spg', 'bpg', 'ppg']
+  roster: ['player', 'gp', 'gs', 'mpg', 'fg%', '3fg%', 'ft%', 'rpg', 'apg', 'spg', 'bpg', 'ppg'],
 }
 
-//https://en.wikipedia.org/wiki/Template:NBA_player_statistics_start
-const parseNBA = function(section) {
-  let wiki = section.wiki
-  wiki = wiki.replace(/\{\{nba (coach|player|roster) statistics start([\s\S]+?)\{\{s-end\}\}/gi, (tmpl, name) => {
+/**
+ * https://en.wikipedia.org/wiki/Template:NBA_player_statistics_start
+ *
+ * @private
+ * @param {Catcher} catcher
+ */
+const parseNBA = function (catcher) {
+  catcher.text = catcher.text.replace(/\{\{nba (coach|player|roster) statistics start([\s\S]+?)\{\{s-end\}\}/gi, (tmpl, name) => {
     tmpl = tmpl.replace(/^\{\{.*?\}\}/, '')
     tmpl = tmpl.replace(/\{\{s-end\}\}/, '')
     name = name.toLowerCase().trim()
+
     let headers = '! ' + keys[name].join(' !! ')
     let table = '{|\n' + headers + '\n' + tmpl + '\n|}'
     let rows = tableParser(table)
-
     rows = rows.map(row => {
       Object.keys(row).forEach(k => {
         row[k] = row[k].text()
       })
       return row
     })
-    section.templates.push({
+
+    catcher.templates.push({
       template: 'NBA ' + name + ' statistics',
-      data: rows
+      data: rows,
     })
+
+    //return empty string to remove the template from the wiki text
     return ''
   })
-  section.wiki = wiki
 }
 module.exports = parseNBA

--- a/src/02-section/toJson.js
+++ b/src/02-section/toJson.js
@@ -20,7 +20,7 @@ const toJSON = function(section, options) {
     data.title = section.title()
   }
   if (options.depth === true) {
-    data.depth = section.depth
+    data.depth = section._depth
   }
   //these return objects
   if (options.paragraphs === true) {

--- a/src/02-section/toJson.js
+++ b/src/02-section/toJson.js
@@ -20,7 +20,7 @@ const toJSON = function(section, options) {
     data.title = section.title()
   }
   if (options.depth === true) {
-    data.depth = section._depth
+    data.depth = section.depth()
   }
   //these return objects
   if (options.paragraphs === true) {

--- a/src/03-paragraph/index.js
+++ b/src/03-paragraph/index.js
@@ -8,7 +8,7 @@ const parse = {
 }
 
 const parseParagraphs = function (section, doc) {
-  let wiki = section.wiki
+  let wiki = section._wiki
   let paragraphs = wiki.split(twoNewLines)
   //don't create empty paragraphs
   paragraphs = paragraphs.filter((p) => p && p.trim().length > 0)
@@ -21,13 +21,13 @@ const parseParagraphs = function (section, doc) {
     }
     //parse the lists
     parse.list(paragraph)
-    // parse images
+    //parse images
     parse.image(paragraph, doc)
     //parse the sentences
     parseSentences(paragraph)
     return new Paragraph(paragraph)
   })
-  section.wiki = wiki
-  section.paragraphs = paragraphs
+  section._wiki = wiki
+  section._paragraphs = paragraphs
 }
 module.exports = parseParagraphs

--- a/src/_data/i18n.js
+++ b/src/_data/i18n.js
@@ -1,5 +1,17 @@
-// wikipedia special terms lifted and augmented from parsoid parser april 2015
-// and then manually on March 2020
+/**
+ * wikipedia special terms lifted and augmented from parsoid parser april 2015
+ * and then manually on March 2020
+ *
+ * @private
+ * @type {{
+ *  images: string[],
+ *  references: string[],
+ *  redirects: string[],
+ *  infoboxes: string[],
+ *  categories: string[],
+ *   disambig: string[]
+ * }}
+ */
 module.exports = {
   categories: require('./categories'),
   disambig: require('./disambig'),
@@ -8,51 +20,52 @@ module.exports = {
   redirects: require('./redirects'),
   references: require('./references')
 
-  // specials: [
-  //   'спэцыяльныя',
-  //   'especial',
-  //   'speciální',
-  //   'spezial',
-  //   'special',
-  //   'ویژه',
-  //   'toiminnot',
-  //   'kerfissíða',
-  //   'arnawlı',
-  //   'spécial',
-  //   'speciaal',
-  //   'посебно',
-  //   'özel',
-  //   '特別'
-  // ],
-  // users: [
-  //   'удзельнік',
-  //   'usuari',
-  //   'uživatel',
-  //   'benutzer',
-  //   'user',
-  //   'usuario',
-  //   'کاربر',
-  //   'käyttäjä',
-  //   'notandi',
-  //   'paydalanıwshı',
-  //   'utilisateur',
-  //   'gebruiker',
-  //   'корисник',
-  //   'kullanıcı',
-  //   '利用者'
-  // ],
-  // sources: [
-  //   //blacklist these headings, as they're not plain-text
-  //   'references',
-  //   'see also',
-  //   'external links',
-  //   'further reading',
-  //   'notes et références',
-  //   'voir aussi',
-  //   'liens externes',
-  //   '参考文献', //references (ja)
-  //   '脚注', //citations (ja)
-  //   '関連項目', //see also (ja)
-  //   '外部リンク' //external links (ja)
-  // ]
+  //specials: [
+  //'спэцыяльныя',
+  //'especial',
+  //'speciální',
+  //'spezial',
+  //'special',
+  //'ویژه',
+  //'toiminnot',
+  //'kerfissíða',
+  //'arnawlı',
+  //'spécial',
+  //'speciaal',
+  //'посебно',
+  //'özel',
+  //'特別'
+  //],
+  //users: [
+  //'удзельнік',
+  //'usuari',
+  //'uživatel',
+  //'benutzer',
+  //'user',
+  //'usuario',
+  //'کاربر',
+  //'käyttäjä',
+  //'notandi',
+  //'paydalanıwshı',
+  //'utilisateur',
+  //'gebruiker',
+  //'корисник',
+  //'kullanıcı',
+  //'利用者'
+  //],
+
+  //sources: [
+  ////blacklist these headings, as they're not plain-text
+  //'references',
+  //'see also',
+  //'external links',
+  //'further reading',
+  //'notes et références',
+  //'voir aussi',
+  //'liens externes',
+  //'参考文献', //references (ja)
+  //'脚注', //citations (ja)
+  //'関連項目', //see also (ja)
+  //'外部リンク' //external links (ja)
+  //]
 }

--- a/src/_fetch/00-parseUrl.js
+++ b/src/_fetch/00-parseUrl.js
@@ -1,10 +1,17 @@
-const parseUrl = function(url) {
+/**
+ * parses out the domain and title from a url
+ *
+ * @private
+ * @param {string} url the url that will be parsed
+ * @returns {{domain: string, title: string}} the domain and title of a url
+ */
+const parseUrl = function (url) {
   let parsed = new URL(url) //eslint-disable-line
   let title = parsed.pathname.replace(/^\/(wiki\/)?/, '')
   title = decodeURIComponent(title)
   return {
     domain: parsed.host,
-    title: title
+    title: title,
   }
 }
 module.exports = parseUrl

--- a/src/_fetch/01-makeUrl.js
+++ b/src/_fetch/01-makeUrl.js
@@ -1,3 +1,5 @@
+const {isArray} = require('../_lib/helpers');
+
 const isInterWiki = /(wikibooks|wikidata|wikimedia|wikinews|wikipedia|wikiquote|wikisource|wikispecies|wikiversity|wikivoyage|wiktionary|foundation|meta)\.org/
 
 const defaults = {
@@ -11,6 +13,12 @@ const defaults = {
   redirects: 'true',
 }
 
+/**
+ *
+ * @private
+ * @param {Object<string, string | number | boolean>} obj
+ * @return {string}
+ */
 const toQueryString = function (obj) {
   return Object.entries(obj)
     .map(([key, value]) => {
@@ -19,22 +27,25 @@ const toQueryString = function (obj) {
     .join('&')
 }
 
-const isArray = function (arr) {
-  return Object.prototype.toString.call(arr) === '[object Array]'
-}
-
+/**
+ * cleans and prepares the tile by replacing the spaces with underscores (_) and trimming the whitespaces of the ends
+ *
+ * @private
+ * @param {string} page the title that needs cleaning
+ * @returns {string} the cleaned title
+ */
 const cleanTitle = (page) => {
   page = page.replace(/ /g, '_')
   page = page.trim()
-  // page = encodeURIComponent(page)
+  //page = encodeURIComponent(page)
   return page
 }
 
 const makeUrl = function (options) {
   let params = Object.assign({}, defaults)
-  // default url
+  //default url
   let url = `https://${options.lang}.${options.wiki}.org/w/api.php?`
-  // from a 3rd party wiki
+  //from a 3rd party wiki
   options.domain = options.domain || options.wikiUrl //support old syntax
   if (options.domain) {
     let path = options.path
@@ -47,7 +58,7 @@ const makeUrl = function (options) {
   if (!options.follow_redirects) {
     delete params.redirects
   }
-  // support numerical ids
+  //support numerical ids
   let page = options.title
   if (typeof page === 'number') {
     params.pageids = page //single pageId
@@ -57,10 +68,10 @@ const makeUrl = function (options) {
     //support array
     params.titles = page.map(cleanTitle).join('|')
   } else {
-    // single page
+    //single page
     params.titles = cleanTitle(page)
   }
-  // make it!
+  //make it!
   url += toQueryString(params)
   return url
 }

--- a/src/_fetch/02-getResult.js
+++ b/src/_fetch/02-getResult.js
@@ -1,14 +1,23 @@
-//this data-format from mediawiki api is nutso
+/**
+ * parses the media wiki api response to something we can use
+ *
+ * the data-format from mediawiki api is nutso
+ *
+ * @private
+ * @param data
+ * @param {fetchDefaults} options
+ * @returns {*}
+ */
 const getResult = function (data, options) {
   options = options || {}
   let pages = Object.keys(data.query.pages)
-  let docs = pages.map((id) => {
+  return pages.map((id) => {
     let page = data.query.pages[id] || {}
     if (page.hasOwnProperty('missing') || page.hasOwnProperty('invalid')) {
       return null
     }
     let text = page.revisions[0]['*']
-    // console.log(page.revisions[0])
+    //console.log(page.revisions[0])
     //us the 'generator' result format, for the random() method
     if (!text && page.revisions[0].slots) {
       text = page.revisions[0].slots.main['*']
@@ -27,12 +36,11 @@ const getResult = function (data, options) {
       description: page.pageprops['wikibase-shortdesc'],
     })
     try {
-      return { wiki: text, meta: meta }
+      return {wiki: text, meta: meta}
     } catch (e) {
       console.error(e)
       throw e
     }
   })
-  return docs
 }
 module.exports = getResult

--- a/src/_fetch/03-parseDoc.js
+++ b/src/_fetch/03-parseDoc.js
@@ -1,6 +1,11 @@
 const Document = require('../01-document/Document')
-
-//flip response object into proper Doc objs
+/**
+ * this function puts all responses into proper Document objects
+ *
+ * @private
+ * @param {Array} res
+ * @returns {null| Document | Document[]} null if there are no results or Document if there is one responses and Document array if there are multiple responses
+ */
 const parseDoc = function (res) {
   res = res.filter(o => o)
   let docs = res.map(o => {

--- a/src/_fetch/_headers.js
+++ b/src/_fetch/_headers.js
@@ -1,6 +1,23 @@
+/**
+ * @typedef HeaderOptions
+ * @property {string} redirect
+ * @property {*} headers.Origin
+ * @property {string} headers.Content-Type
+ * @property {string} headers.Api-User-Agent
+ * @property {string} headers.User-Agent
+ * @property {string} method
+ */
+
+
+/**
+ * factory for header options
+ *
+ * @private
+ * @param options
+ * @returns {HeaderOptions} the generated options
+ */
 const makeHeaders = function (options) {
-  let agent =
-    options.userAgent || options['User-Agent'] || options['Api-User-Agent'] || 'User of the wtf_wikipedia library'
+  let agent = options.userAgent || options['User-Agent'] || options['Api-User-Agent'] || 'User of the wtf_wikipedia library'
 
   let origin
   if (options.noOrigin) {
@@ -9,7 +26,7 @@ const makeHeaders = function (options) {
     origin = options.origin || options.Origin || '*'
   }
 
-  const opts = {
+  return {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
@@ -19,6 +36,5 @@ const makeHeaders = function (options) {
     },
     redirect: 'follow',
   }
-  return opts
 }
 module.exports = makeHeaders

--- a/src/_fetch/category.js
+++ b/src/_fetch/category.js
@@ -1,14 +1,15 @@
 const http = require('./http/server')
 const makeHeaders = require('./_headers')
+const {isObject} = require('../_lib/helpers')
 
 const defaults = {
   lang: 'en',
   wiki: 'wikipedia',
   domain: null,
-  path: 'w/api.php' //some 3rd party sites use a weird path
+  path: 'w/api.php', //some 3rd party sites use a weird path
 }
 
-const normalizeCategory = function(cat = '') {
+const normalizeCategory = function (cat = '') {
   if (/^Category/i.test(cat) === false) {
     cat = 'Category:' + cat
   }
@@ -16,15 +17,11 @@ const normalizeCategory = function(cat = '') {
   return cat
 }
 
-const isObject = function(obj) {
-  return obj && Object.prototype.toString.call(obj) === '[object Object]'
-}
-
-const getResult = function(body) {
+const getResult = function (body) {
   let list = body.query.categorymembers || []
   let res = {
     pages: [],
-    categories: []
+    categories: [],
   }
   list.forEach(p => {
     if (p.ns === 14) {
@@ -38,7 +35,7 @@ const getResult = function(body) {
   return res
 }
 
-const makeUrl = function(category, options, cm) {
+const makeUrl = function (category, options, cm) {
   category = normalizeCategory(category)
   category = encodeURIComponent(category)
   let url = `https://${options.lang}.wikipedia.org/${options.path}?`
@@ -52,7 +49,7 @@ const makeUrl = function(category, options, cm) {
   return url
 }
 
-const fetchCategory = function(category, lang, options) {
+const fetchCategory = function (category, lang, options) {
   options = options || {}
   options = Object.assign({}, defaults, options)
   //support lang 2nd param
@@ -63,11 +60,11 @@ const fetchCategory = function(category, lang, options) {
   }
   let res = {
     pages: [],
-    categories: []
+    categories: [],
   }
-  // wrap a promise around potentially-many requests
+  //wrap a promise around potentially-many requests
   return new Promise((resolve, reject) => {
-    const doit = function(cm) {
+    const doit = function (cm) {
       let url = makeUrl(category, options, cm)
       const headers = makeHeaders(options)
       return http(url, headers)

--- a/src/_fetch/http/client.js
+++ b/src/_fetch/http/client.js
@@ -1,6 +1,12 @@
-// use the native client-side fetch function
+/**
+ * use the native client-side fetch function
+ *
+ * @private
+ * @param {string} url the url that well be fetched
+ * @param {RequestInit} opts the options for fetch
+ * @returns {Promise<Response>} the response from fetch
+ */
 const request = function (url, opts) {
-  //eslint-disable-next-line
   return fetch(url, opts).then(function (res) {
     return res.json()
   })

--- a/src/_fetch/index.js
+++ b/src/_fetch/index.js
@@ -4,36 +4,67 @@ const getResult = require('./02-getResult')
 const parseDoc = require('./03-parseDoc')
 const http = require('./http/server')
 const makeHeaders = require('./_headers')
+const {isObject} = require('../_lib/helpers')
 const isUrl = /^https?:\/\//
 
+/**
+ * @typedef fetchDefaults
+ * @property {string | undefined} [path]
+ * @property {string | undefined} [wiki]
+ * @property {string | undefined} [domain]
+ * @property {boolean | undefined} [follow_redirects]
+ * @property {string | undefined} [lang]
+ * @property {string | undefined} [path]
+ *
+ *
+ * @property {string | number | Array<string | number>| undefined} [title]
+ *
+ * @property {string | undefined} ["Api-User-Agent"]
+ */
+
+/**
+ *
+ * @type {fetchDefaults}
+ */
 const defaults = {
   lang: 'en',
   wiki: 'wikipedia',
-  domain: null,
+  domain: undefined,
   follow_redirects: true,
   path: 'api.php', //some 3rd party sites use a weird path
 }
 
+/**
+ *  fetches the page from the wiki and returns a Promise with the parsed wikitext
+ *
+ * @param {string | number | Array<number | string>} title the title, PageID, URL or an array of all three of the page(s) you want to fetch
+ * @param {fetchDefaults| function | string} [options] the options for the fetch or the language of the wiki for the article or the callback if you dont provide any options
+ * @param {Function | fetchDefaults} [c] the callback function for the call or the options for the fetch
+ * @returns {Promise<null | Document | Document[]>}
+ */
 const fetch = function (title, options, c) {
   let callback = null
   if (typeof options === 'function') {
     callback = options
-    options = {}
+    options = defaults
   }
+
+  //if the call c is a function then its the callback
   if (typeof c === 'function') {
     callback = c
-    c = {}
   }
+
   //support lang 2nd param
   if (typeof options === 'string') {
-    c = c || {}
-    options = Object.assign({}, { lang: options }, c)
+    options = Object.assign({}, {lang: options}, isObject(c) ? c : defaults)
   }
+
   options = options || {}
   options = Object.assign({}, defaults, options)
   options.title = title
-  // parse url input
-  if (isUrl.test(title)) {
+
+  //parse url input
+  if (typeof title === 'string' && isUrl.test(title)) {
     options = Object.assign(options, parseUrl(title))
   }
 
@@ -41,16 +72,12 @@ const fetch = function (title, options, c) {
   const headers = makeHeaders(options)
   return http(url, headers)
     .then((res) => {
-      try {
-        let data = getResult(res, options)
-        data = parseDoc(data)
-        if (callback) {
-          callback(null, data)
-        }
-        return data
-      } catch (e) {
-        throw e
+      let data = getResult(res, options)
+      data = parseDoc(data)
+      if (callback) {
+        callback(null, data)
       }
+      return data
     })
     .catch((e) => {
       console.error(e)

--- a/src/_fetch/random.js
+++ b/src/_fetch/random.js
@@ -2,15 +2,13 @@ const http = require('./http/server')
 const makeHeaders = require('./_headers')
 const getResult = require('./02-getResult')
 const parseDoc = require('./03-parseDoc')
+const {isObject} = require('../_lib/helpers')
 
 const defaults = {
   lang: 'en',
   wiki: 'wikipedia',
   domain: null,
   path: 'w/api.php', //some 3rd party sites use a weird path
-}
-const isObject = function (obj) {
-  return obj && Object.prototype.toString.call(obj) === '[object Object]'
 }
 
 const fetchRandom = function (lang, options) {

--- a/src/_lib/encode.js
+++ b/src/_lib/encode.js
@@ -1,9 +1,9 @@
-// dumpster-dive throws everything into mongodb  - github.com/spencermountain/dumpster-dive
-// mongo has some opinions about what characters are allowed as keys and ids.
+//dumpster-dive throws everything into mongodb  - github.com/spencermountain/dumpster-dive
+//mongo has some opinions about what characters are allowed as keys and ids.
 //https://stackoverflow.com/questions/12397118/mongodb-dot-in-key-name/30254815#30254815
 const specialChar = /[\\\.$]/
 
-const encodeStr = function(str) {
+const encodeStr = function (str) {
   if (typeof str !== 'string') {
     str = ''
   }
@@ -13,7 +13,7 @@ const encodeStr = function(str) {
   return str
 }
 
-const encodeObj = function(obj = {}) {
+const encodeObj = function (obj = {}) {
   let keys = Object.keys(obj)
   for (let i = 0; i < keys.length; i += 1) {
     if (specialChar.test(keys[i]) === true) {
@@ -28,5 +28,5 @@ const encodeObj = function(obj = {}) {
 }
 
 module.exports = {
-  encodeObj: encodeObj
+  encodeObj: encodeObj,
 }

--- a/src/_lib/helpers.js
+++ b/src/_lib/helpers.js
@@ -1,18 +1,62 @@
-module.exports = {
-  capitalise: function(str) {
-    if (str && typeof str === 'string') {
-      return str.charAt(0).toUpperCase() + str.slice(1)
-    }
-    return ''
-  },
-  trim_whitespace: function(str) {
-    if (str && typeof str === 'string') {
-      str = str.replace(/^\s\s*/, '')
-      str = str.replace(/\s\s*$/, '')
-      str = str.replace(/ {2}/, ' ')
-      str = str.replace(/\s, /, ', ')
-      return str
-    }
-    return ''
+/**
+ * capitalises the input
+ * hello -> Hello
+ * hello there -> Hello there
+ *
+ * @private
+ * @param {string} [str] the string that will be capitalised
+ * @returns {string} the capitalised string
+ */
+function capitalise(str) {
+  if (str && typeof str === 'string') {
+    return str.charAt(0).toUpperCase() + str.slice(1)
   }
+  return ''
+}
+
+/**
+ * trim whitespaces of the ends normalize 2 spaces into one and removes whitespaces before commas
+ *
+ * @private
+ * @param {string} [str] the string that will be processed
+ * @returns {string} the processed string
+ */
+function trim_whitespace(str) {
+  if (str && typeof str === 'string') {
+    str = str.replace(/^\s\s*/, '')
+    str = str.replace(/\s\s*$/, '')
+    str = str.replace(/ {2}/, ' ')
+    str = str.replace(/\s, /, ', ')
+    return str
+  }
+  return ''
+}
+
+/**
+ * determines if an variable is an array or not
+ *
+ * @private
+ * @param {*} x the variable that needs to be checked
+ * @returns {boolean} whether the variable is an array
+ */
+function isArray(x) {
+  return Object.prototype.toString.call(x) === '[object Array]'
+}
+
+/**
+ *  determines if an variable is an object or not
+ *
+ * @private
+ * @param {*} x the variable that needs to be checked
+ * @returns {boolean} whether the variable is an object
+ */
+function isObject(x) {
+  return (x && Object.prototype.toString.call(x) === '[object Object]')
+}
+
+module.exports = {
+  capitalise,
+  trim_whitespace,
+  isArray,
+  isObject
 }

--- a/src/_lib/setDefaults.js
+++ b/src/_lib/setDefaults.js
@@ -1,5 +1,12 @@
-//
-const setDefaults = function(options, defaults) {
+/**
+ * applies the the key values of defaults to options
+ *
+ * @private
+ * @param {{}} options the user options
+ * @param {{}} defaults the defaults
+ * @returns {{}} the user options with the defaults applied
+ */
+const setDefaults = function (options, defaults) {
   return Object.assign({}, defaults, options)
 }
 module.exports = setDefaults

--- a/src/link/Link.js
+++ b/src/link/Link.js
@@ -1,28 +1,27 @@
 const wikis = require('../_data/interwiki')
 
 const defaults = {
-  type: 'internal'
+  type: 'internal',
 }
-const Link = function(data) {
+const Link = function (data) {
   data = data || {}
   data = Object.assign({}, defaults, data)
-  // console.log(data)
   Object.defineProperty(this, 'data', {
     enumerable: false,
-    value: data
+    value: data,
   })
 }
 const methods = {
-  text: function(str) {
+  text: function (str) {
     if (str !== undefined) {
       this.data.text = str
     }
     return this.data.text
   },
-  json: function() {
+  json: function () {
     let obj = {
       text: this.text(),
-      type: this.type()
+      type: this.type(),
     }
     if (obj.type === 'internal') {
       obj.page = this.page()
@@ -37,38 +36,38 @@ const methods = {
     }
     return obj
   },
-  page: function(str) {
+  page: function (str) {
     if (str !== undefined) {
       this.data.page = str
     }
     return this.data.page
   },
-  anchor: function(str) {
+  anchor: function (str) {
     if (str !== undefined) {
       this.data.anchor = str
     }
     return this.data.anchor || ''
   },
-  wiki: function(str) {
+  wiki: function (str) {
     if (str !== undefined) {
       this.data.wiki = str
     }
     return this.data.wiki
   },
-  type: function(str) {
+  type: function (str) {
     if (str !== undefined) {
       this.data.type = str
     }
     return this.data.type
   },
-  site: function(str) {
+  site: function (str) {
     if (str !== undefined) {
       this.data.site = str
     }
     return this.data.site
   },
-  // create a url for any type of link
-  href: function() {
+  //create a url for any type of link
+  href: function () {
     let type = this.type()
     if (type === 'external') {
       return this.site()
@@ -89,12 +88,12 @@ const methods = {
       //internal link
       url = `./${this.page()}`
     }
-    // add anchor on the end
+    //add anchor on the end
     if (this.anchor()) {
       url += '#' + this.anchor()
     }
     return url
-  }
+  },
 }
 Object.keys(methods).forEach(k => {
   Link.prototype[k] = methods[k]

--- a/src/reference/index.js
+++ b/src/reference/index.js
@@ -1,14 +1,14 @@
 const parse = require('../template/_parsers/parse')
-// const parse = require('../../templates/wikipedia/page').citation;
+//const parse = require('../../templates/wikipedia/page').citation;
 const parseSentence = require('../04-sentence').fromText
 const Reference = require('./Reference')
 
 //structured Cite templates - <ref>{{Cite..</ref>
-const hasCitation = function(str) {
+const hasCitation = function (str) {
   return /^ *?\{\{ *?(cite|citation)/i.test(str) && /\}\} *?$/.test(str) && /citation needed/i.test(str) === false
 }
 
-const parseCitation = function(tmpl) {
+const parseCitation = function (tmpl) {
   let obj = parse(tmpl)
   obj.type = obj.template.replace(/cite /, '')
   obj.template = 'citation'
@@ -16,21 +16,22 @@ const parseCitation = function(tmpl) {
 }
 
 //handle unstructured ones - <ref>some text</ref>
-const parseInline = function(str) {
+const parseInline = function (str) {
   let obj = parseSentence(str) || {}
   return {
     template: 'citation',
     type: 'inline',
     data: {},
-    inline: obj
+    inline: obj,
   }
 }
 
-// parse <ref></ref> xml tags
-const parseRefs = function(section) {
+//parse <ref></ref> xml tags
+const parseRefs = function (section) {
   let references = []
-  let wiki = section.wiki
-  wiki = wiki.replace(/ ?<ref>([\s\S]{0,1800}?)<\/ref> ?/gi, function(a, tmpl) {
+  let wiki = section._wiki
+
+  wiki = wiki.replace(/ ?<ref>([\s\S]{0,1800}?)<\/ref> ?/gi, function (_a, tmpl) {
     if (hasCitation(tmpl)) {
       let obj = parseCitation(tmpl)
       if (obj) {
@@ -42,10 +43,12 @@ const parseRefs = function(section) {
     }
     return ' '
   })
-  // <ref name=""/>
+
+  //<ref name=""/>
   wiki = wiki.replace(/ ?<ref [^>]{0,200}?\/> ?/gi, ' ')
-  // <ref name=""></ref>
-  wiki = wiki.replace(/ ?<ref [^>]{0,200}?>([\s\S]{0,1800}?)<\/ref> ?/gi, function(a, tmpl) {
+
+  //<ref name=""></ref>
+  wiki = wiki.replace(/ ?<ref [^>]{0,200}?>([\s\S]{0,1800}?)<\/ref> ?/gi, function (a, tmpl) {
     if (hasCitation(tmpl)) {
       let obj = parseCitation(tmpl)
       if (obj) {
@@ -57,9 +60,11 @@ const parseRefs = function(section) {
     }
     return ' '
   })
+
   //now that we're done with xml, do a generic + dangerous xml-tag removal
   wiki = wiki.replace(/ ?<[ \/]?[a-z0-9]{1,8}[a-z0-9=" ]{2,20}[ \/]?> ?/g, ' ') //<samp name="asd">
-  section.references = references.map(r => new Reference(r))
-  section.wiki = wiki
+  section._references = references.map(r => new Reference(r))
+  section._wiki = wiki
 }
+
 module.exports = parseRefs

--- a/src/table/index.js
+++ b/src/table/index.js
@@ -1,13 +1,13 @@
 const parseTable = require('./parse')
 const Table = require('./Table')
-// const table_reg = /\{\|[\s\S]+?\|\}/g; //the largest-cities table is ~70kchars.
+//const table_reg = /\{\|[\s\S]+?\|\}/g; //the largest-cities table is ~70k chars.
 const openReg = /^\s*{\|/
 const closeReg = /^\s*\|}/
 
 //tables can be recursive, so looky-here.
-const findTables = function(section) {
+const findTables = function (section) {
   let list = []
-  let wiki = section.wiki
+  let wiki = section._wiki
   let lines = wiki.split('\n')
   let stack = []
   for (let i = 0; i < lines.length; i += 1) {
@@ -32,7 +32,7 @@ const findTables = function(section) {
   let tables = []
   list.forEach(str => {
     if (str) {
-      //also reremove a newline at the end of the table (awkward)
+      //also re-remove a newline at the end of the table (awkward)
       wiki = wiki.replace(str + '\n', '')
       wiki = wiki.replace(str, '')
       let data = parseTable(str)
@@ -43,9 +43,9 @@ const findTables = function(section) {
   })
 
   if (tables.length > 0) {
-    section.tables = tables
+    section._tables = tables
   }
-  section.wiki = wiki
+  section._wiki = wiki
 }
 
 module.exports = findTables

--- a/src/template/_parsers/01-pipe-splitter.js
+++ b/src/template/_parsers/01-pipe-splitter.js
@@ -1,6 +1,12 @@
-//turn {{name|one|two|three}} into [name, one, two, three]
-const pipeSplitter = function(tmpl) {
-  //start with a naiive '|' split
+/**
+ * turn {{name|one|two|three}} into [name, one, two, three]
+ *
+ * @private
+ * @param {string} tmpl the template text
+ * @returns {string[]} a array containing all the split parameters
+ */
+const pipeSplitter = function (tmpl) {
+  //start with a naive '|' split
   let arr = tmpl.split(/\n?\|/)
   //we've split by '|', which is pretty lame
   //look for broken-up links and fix them :/
@@ -9,19 +15,21 @@ const pipeSplitter = function(tmpl) {
       return
     }
     //has '[[' but no ']]'
-    //has equal number of openning and closing tags. handle nested case '[[[[' ']]'
-    if (/\[\[[^\]]+$/.test(a) || /\{\{[^\}]+$/.test(a)
-    || 
-      (a.split('{{').length !== a.split('}}').length)
+    //has equal number of opening and closing tags. handle nested case '[[[[' ']]'
+    if (
+      /\[\[[^\]]+$/.test(a) || /{{[^}]+$/.test(a)
+      || (a.split('{{').length !== a.split('}}').length)
       || (a.split('[[').length !== a.split(']]').length)
     ) {
       arr[i + 1] = arr[i] + '|' + arr[i + 1]
+      //@ts-expect-error we can ignore this error because we filter out all nulls later in
       arr[i] = null
     }
   })
   //cleanup any mistakes we've made
   arr = arr.filter(a => a !== null)
   arr = arr.map(a => (a || '').trim())
+
   //remove empty fields, only at the end:
   for (let i = arr.length - 1; i >= 0; i -= 1) {
     if (arr[i] === '') {

--- a/src/template/_parsers/02-keyMaker.js
+++ b/src/template/_parsers/02-keyMaker.js
@@ -6,11 +6,11 @@ const hasKey = /^[a-z0-9\u00C0-\u00FF\._\- '()œ]+=/iu
 const reserved = {
   template: true,
   list: true,
-  prototype: true
+  prototype: true,
 }
 
 //turn 'key=val' into {key:key, val:val}
-const parseKey = function(str) {
+const parseKey = function (str) {
   let parts = str.split('=')
   let key = parts[0] || ''
   key = key.toLowerCase().trim()
@@ -21,15 +21,23 @@ const parseKey = function(str) {
   }
   return {
     key: key,
-    val: val.trim()
+    val: val.trim(),
   }
 }
 
-//turn [a, b=v, c] into {'1':a, b:v, '2':c}
-const keyMaker = function(arr, order) {
-  let o = 0
-  return arr.reduce((h, str) => {
-    str = (str || '').trim()
+/**
+ * turn [a, b=v, c] into {'1':a, b:v, '2':c}
+ *
+ * @private
+ * @param {string[]} arr the array of parameters
+ * @param {string[]} [order] the order in which the parameters are returned
+ * @returns {{}} and object with the names as the keys and the values as the values
+ */
+const keyMaker = function (arr, order) {
+  let keyIndex = 0
+  return arr.reduce((h, str = '') => {
+    str = str.trim()
+
     //support named keys - 'foo=bar'
     if (hasKey.test(str) === true) {
       let res = parseKey(str)
@@ -38,15 +46,17 @@ const keyMaker = function(arr, order) {
         return h
       }
     }
-    //try a key from given 'order' names
-    if (order && order[o]) {
-      let key = order[o] //here goes!
+
+    //if the current index is present in the order array then we have a name for the key
+    if (order && order[keyIndex]) {
+      let key = order[keyIndex]
       h[key] = str
     } else {
       h.list = h.list || []
       h.list.push(str)
     }
-    o += 1
+
+    keyIndex += 1
     return h
   }, {})
 }

--- a/src/template/_parsers/_strip.js
+++ b/src/template/_parsers/_strip.js
@@ -1,7 +1,14 @@
-//remove the top/bottom off the template
-const strip = function(tmpl) {
-  tmpl = tmpl.replace(/^\{\{/, '')
-  tmpl = tmpl.replace(/\}\}$/, '')
+/**
+ * removes the top and bottom off the template
+ * so it removes tje '{{' and '}}'
+ *
+ * @private
+ * @param {string} tmpl the string to be striped
+ * @returns {string} the striped string
+ */
+const strip = function (tmpl) {
+  tmpl = tmpl.replace(/^{{/, '')
+  tmpl = tmpl.replace(/}}$/, '')
   return tmpl
 }
 module.exports = strip

--- a/src/template/_parsers/parse.js
+++ b/src/template/_parsers/parse.js
@@ -6,8 +6,15 @@ const pipeSplitter = require('./01-pipe-splitter')
 const keyMaker = require('./02-keyMaker')
 const cleanup = require('./03-cleanup')
 
-// most templates just want plaintext...
-const makeFormat = function(str, fmt) {
+/**
+ * most templates just want plaintext...
+ *
+ * @private
+ * @param str
+ * @param {'json' | 'raw'} [fmt]
+ * @returns {Sentence|string|Object}
+ */
+const makeFormat = function (str, fmt) {
   let s = parseSentence(str)
   //support various output formats
   if (fmt === 'json') {
@@ -19,20 +26,31 @@ const makeFormat = function(str, fmt) {
   return s.text()
 }
 
-//
-const parser = function(tmpl, order, fmt) {
-  order = order || []
-  //renomove {{}}'s
+/**
+ * parses the parameters of a template to a usable format
+ *
+ * @private
+ * @param {string} tmpl the template text
+ * @param {string[]} [order] the order in which the parameters are returned
+ * @param {'json' | 'raw'} [fmt] whether you wan to parse the text of the template the raw object or just the text
+ * @returns {Object} the parameters of the template in a usable format
+ */
+const parser = function (tmpl, order = [], fmt) {
+  //remove {{}}'s and split based on pipes
   tmpl = strip(tmpl || '')
   let arr = pipeSplitter(tmpl)
+
   //get template name
   let name = arr.shift()
+
   //name each value
   let obj = keyMaker(arr, order)
+
   //remove wiki-junk
   obj = cleanup(obj)
+
   //is this a infobox/reference?
-  // let known = isKnown(obj);
+  //let known = isKnown(obj);
 
   //using '|1=content' is an escaping-thing..
   if (obj['1'] && order[0] && obj.hasOwnProperty(order[0]) === false) {
@@ -48,6 +66,7 @@ const parser = function(tmpl, order, fmt) {
     }
     obj[k] = makeFormat(obj[k], fmt)
   })
+
   //add the template name
   if (name) {
     obj.template = fmtName(name)

--- a/src/template/index.js
+++ b/src/template/index.js
@@ -25,7 +25,7 @@ const isInfobox = function (obj) {
 
 //reduce the scary recursive situations
 const allTemplates = function (section, doc) {
-  let wiki = section.wiki
+  let wiki = section._wiki
   //nested data-structure of templates
   let list = findTemplates(wiki)
   let keep = []
@@ -53,30 +53,30 @@ const allTemplates = function (section, doc) {
   list.forEach((node) => parseThem(node, null))
 
   //sort-out the templates we decide to keep
-  section.infoboxes = section.infoboxes || []
-  section.references = section.references || []
-  section.templates = section.templates || []
-  section.templates = section.templates.concat(keep)
+  section._infoboxes = section._infoboxes || []
+  section._references = section._references || []
+  section._templates = section._templates || []
+  section._templates = section._templates.concat(keep)
   //remove references and infoboxes from our list
-  section.templates = section.templates.filter((obj) => {
+  section._templates = section._templates.filter((obj) => {
     if (isReference(obj) === true) {
-      section.references.push(new Reference(obj))
+      section._references.push(new Reference(obj))
       return false
     }
     if (isInfobox(obj) === true) {
       obj.domain = doc._domain
-      section.infoboxes.push(new Infobox(obj))
+      section._infoboxes.push(new Infobox(obj))
       return false
     }
     return true
   })
-  section.templates = section.templates.map((obj) => new Template(obj))
+  section._templates = section._templates.map((obj) => new Template(obj))
 
   //remove the templates from our wiki text
   list.forEach((node) => {
     wiki = wiki.replace(node.body, node.out)
   })
-  section.wiki = wiki
+  section._wiki = wiki
 }
 
 module.exports = allTemplates

--- a/src/template/parse.js
+++ b/src/template/parse.js
@@ -3,28 +3,26 @@ const parse = require('./_parsers/parse')
 const inf = require('./_infobox')
 const templates = require('./templates')
 const generic = require('./_parsers/parse')
+const {isArray} = require('../_lib/helpers')
+
 const nums = ['0', '1', '2', '3', '4', '5', '6', '7', '8']
 
-const isArray = function(arr) {
-  return Object.prototype.toString.call(arr) === '[object Array]'
-}
-
 //this gets all the {{template}} strings and decides how to parse them
-const parseTemplate = function(tmpl, list) {
+const parseTemplate = function (tmpl, list) {
   let name = tmpl.name
 
   if (ignore.hasOwnProperty(name) === true) {
     return ''
   }
 
-  // {{infobox settlement...}}
+  //{{infobox settlement...}}
   if (inf.isInfobox(name) === true) {
     let obj = parse(tmpl.body, list, 'raw')
     let infobox = inf.format(obj)
     list.push(infobox)
     return ''
   }
-  // //cite book, cite arxiv...
+  //cite book, cite arxiv...
   if (/^cite [a-z]/.test(name) === true) {
     let obj = parse(tmpl.body, list)
     obj.type = obj.template
@@ -33,36 +31,36 @@ const parseTemplate = function(tmpl, list) {
     return ''
   }
 
-  // known template
+  //known template
   if (templates.hasOwnProperty(name) === true) {
-    // handle number-syntax
+    //handle number-syntax
     if (typeof templates[name] === 'number') {
       let obj = generic(tmpl.body, nums)
       let key = String(templates[name])
       return obj[key] || ''
     }
-    // handle string-syntax
+    //handle string-syntax
     if (typeof templates[name] === 'string') {
       return templates[name]
     }
-    // handle array sytax
+    //handle array sytax
     if (isArray(templates[name]) === true) {
       let obj = generic(tmpl.body, templates[name])
       list.push(obj)
       return ''
     }
-    // handle function syntax
+    //handle function syntax
     if (typeof templates[name] === 'function') {
       return templates[name](tmpl.body, list)
     }
   }
 
-  // unknown template, try to parse it
+  //unknown template, try to parse it
   let parsed = parse(tmpl.body)
   if (list && Object.keys(parsed).length > 0) {
     list.push(parsed)
   }
-  // ..then remove it
+  //..then remove it
   return ''
 }
 module.exports = parseTemplate

--- a/tests/Document.test.js
+++ b/tests/Document.test.js
@@ -383,13 +383,9 @@ test('sections - get - if the clue is a undefined / unset return the list of cat
   let str = fs.readFileSync(path.join(__dirname, 'cache', 'Charlie-Milstead.txt'), 'utf-8')
   let doc = wtf(str)
 
-  const expected = [
-    {depth: 0, _title: ''},
-    {depth: 0, _title: 'Career'},
-    {depth: 0, _title: 'References'},
-  ]
+  const expected = [321, 401, 0]
 
-  t.deepEqual(JSON.stringify(doc.sections()), JSON.stringify(expected), 'the sections in the wiki text')
+  t.deepEqual(doc.sections().map(s => s.text().length), expected, 'the sections in the wiki text')
   t.end()
 })
 
@@ -397,7 +393,7 @@ test('sections - get - if the clue is a number return the sections in that index
   let str = fs.readFileSync(path.join(__dirname, 'cache', 'Charlie-Milstead.txt'), 'utf-8')
   let doc = wtf(str)
 
-  t.equal(JSON.stringify(doc.sections(1)), JSON.stringify({depth: 0, _title: 'Career'}), 'the section at index 1')
+  t.equal(doc.sections(1).text().length, 401, 'the section at index 1')
   t.end()
 })
 
@@ -405,10 +401,7 @@ test('sections - get - if the clue is a string return the sections of that title
   let str = fs.readFileSync(path.join(__dirname, 'cache', 'Charlie-Milstead.txt'), 'utf-8')
   let doc = wtf(str)
 
-  t.equal(JSON.stringify(doc.sections('Career')), JSON.stringify({
-    depth: 0,
-    _title: 'Career',
-  }), 'the section at index 1')
+  t.equal(doc.sections('Career').text().length, 401, 'the section with the title "Career"')
   t.end()
 })
 
@@ -416,10 +409,7 @@ test('sections - get - if the clue is a string return the sections of that title
   let str = fs.readFileSync(path.join(__dirname, 'cache', 'Charlie-Milstead.txt'), 'utf-8')
   let doc = wtf(str)
 
-  t.equal(JSON.stringify(doc.sections('CAREER')), JSON.stringify({
-    depth: 0,
-    _title: 'Career',
-  }), 'the section at index 1')
+  t.equal(doc.sections('CAREER').text().length, 401, 'the section with the title "Career"')
   t.end()
 })
 
@@ -1012,7 +1002,7 @@ test('json - get - get the json version of the document', (t) => {
   let doc = wtf(str)
 
   //I used the length of the paragraphs as an analogue for the content.
-  t.deepEqual(JSON.stringify(doc.json()).length, 1971, 'version of the document')
+  t.deepEqual(JSON.stringify(doc.json()).length, 1971, 'JSON version of the document')
   t.end()
 })
 //debug
@@ -1051,7 +1041,9 @@ test('plurals / singular - all should exist', (t) => {
   let singels = {
     'section': [
       {
-        clue: undefined, json: true, expected: {
+        clue: undefined,
+        json: true,
+        expected: {
           'title': '',
           'depth': 0,
           'paragraphs': [{

--- a/tests/Section.test.js
+++ b/tests/Section.test.js
@@ -1,0 +1,317 @@
+const test = require('tape')
+const wtf = require('./lib')
+const fs = require('fs')
+const path = require('path')
+
+//title
+test('Tile - get', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'Chemical-biology.txt'), 'utf-8')
+  let sec = wtf(str).section(1)
+  t.equal(sec.title(), 'Introduction', 'the title should equal "Introduction"')
+  t.end()
+})
+
+test('Tile - get - with no title', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'Chemical-biology.txt'), 'utf-8')
+  let sec = wtf(str).section(0)
+  t.equal(sec.title(), '', 'the title should equal ""')
+  t.end()
+})
+
+//index
+test('index - get', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'Chemical-biology.txt'), 'utf-8')
+  let sec = wtf(str).section(1)
+  t.equal(sec.index(), 1, 'the index should equal "1"')
+  t.end()
+})
+
+//indentation
+test('indentation - get', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'Chemical-biology.txt'), 'utf-8')
+  let sec = wtf(str).section(1)
+
+  t.equal(sec.indentation(), 0, 'the index should equal "0"')
+  t.end()
+})
+
+test('indentation - get', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'Chemical-biology.txt'), 'utf-8')
+  let sec = wtf(str).section(3)
+  t.equal(sec.indentation(), 1, 'the index should equal "1"')
+  t.end()
+})
+
+//sentences
+test('sentences - get', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'Chemical-biology.txt'), 'utf-8')
+  let sec = wtf(str).section(3)
+
+  const expected = [109, 229, 118, 120, 95, 94, 192, 107, 138, 143, 165, 155, 39, 100, 197, 101]
+  t.deepEqual(sec.sentences().map(s => s.text().length), expected, 'the index should equal the expected')
+  t.end()
+})
+
+test('sentences - get - number', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'Chemical-biology.txt'), 'utf-8')
+  let sec = wtf(str).section(3)
+
+  t.equal(sec.sentences(1).text().length, 229, 'the index should equal the expected')
+  t.end()
+})
+
+//paragraphs
+test('paragraphs - get', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'Chemical-biology.txt'), 'utf-8')
+  let sec = wtf(str).section(3)
+
+  const expected = [675, 1141, 299]
+  t.deepEqual(sec.paragraphs().map(s => s.text().length), expected, 'the paragraphs should equal the expected')
+  t.end()
+})
+
+test('paragraphs - get - number', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'Chemical-biology.txt'), 'utf-8')
+  let sec = wtf(str).section(3)
+
+  t.equal(sec.paragraphs(1).text().length, 1141, 'the paragraphs should equal the expected')
+  t.end()
+})
+
+//paragraph
+test('paragraphs - get', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'Chemical-biology.txt'), 'utf-8')
+  let sec = wtf(str).section(3)
+
+  t.equal(sec.paragraph().text().length, 675, 'the paragraphs should equal the expected')
+  t.end()
+})
+
+test('paragraphs - get - number', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'Chemical-biology.txt'), 'utf-8')
+  let sec = wtf(str).section(3)
+
+  t.equal(sec.paragraph(1).text().length, 1141, 'the paragraphs should equal the expected')
+  t.end()
+})
+//links
+test('links - get', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'Chemical-biology.txt'), 'utf-8')
+  let sec = wtf(str).section(3)
+
+  const expected = [12, 10, 19, 34, 30, 25, 19, 25, 7, 21]
+  t.deepEqual(sec.links().map(l => l.href().length), expected, 'the links should equal the expected')
+  t.end()
+})
+
+test('links - get - number', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'Chemical-biology.txt'), 'utf-8')
+  let sec = wtf(str).section(3)
+
+  t.equal(sec.links(1).href().length, 10, 'the links should equal the expected')
+  t.end()
+})
+
+test('links - get - string', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'Chemical-biology.txt'), 'utf-8')
+  let sec = wtf(str).section(3)
+
+  t.equal(sec.links('protein sequences')[0].href().length, 19, 'the links should equal the expected')
+  t.end()
+})
+
+//tables
+test('tables - get', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', '2008-British-motorcycle-Grand-Prix.txt'), 'utf-8')
+  let sec = wtf(str).section(1)
+
+  const expected = [18]
+  t.deepEqual(sec.tables().map(s => s.keyValue().length), expected, 'the tables should equal the expected')
+  t.end()
+})
+
+test('tables - get - number', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', '2008-British-motorcycle-Grand-Prix.txt'), 'utf-8')
+  let sec = wtf(str).section(1)
+
+  t.equal(sec.tables(0).keyValue().length, 18, 'the tables should equal the expected')
+  t.end()
+})
+
+//templates
+test('templates - get', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'United-Kingdom.txt'), 'utf-8')
+  let sec = wtf(str).section(0)
+
+  const expected = [148, 195, 54, 49, 727, 176, 182, 399, 70, 23, 18, 18, 21]
+  t.deepEqual(sec.templates().map(s => JSON.stringify(s).length), expected, 'the templates should equal the expected')
+  t.end()
+})
+
+test('templates - get - number', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'United-Kingdom.txt'), 'utf-8')
+  let sec = wtf(str).section(0)
+
+  t.equal(JSON.stringify(sec.templates(1)).length, 195, 'the templates should equal the expected')
+  t.end()
+})
+
+test('templates - get - string', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'United-Kingdom.txt'), 'utf-8')
+  let sec = wtf(str).section(0)
+
+  t.equal(JSON.stringify(sec.templates('coord')).length, 72, 'the templates should equal the expected')
+  t.end()
+})
+
+//infoboxes
+test('infoboxes - get', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'United-Kingdom.txt'), 'utf-8')
+  let sec = wtf(str).section(0)
+
+  const expected = [33]
+  t.deepEqual(sec.infoboxes().map(s => JSON.stringify(s).length), expected, 'the infoboxes should equal the expected')
+  t.end()
+})
+
+test('infoboxes - get - number', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'United-Kingdom.txt'), 'utf-8')
+  let sec = wtf(str).section(0)
+
+  t.equal(JSON.stringify(sec.infoboxes(0)).length, 33, 'the infoboxes should equal the expected')
+  t.end()
+})
+
+//coordinates
+test('coordinates - get', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'United-Kingdom.txt'), 'utf-8')
+  let sec = wtf(str).section(0)
+
+  const expected = [70]
+  t.deepEqual(sec.coordinates().map(s => JSON.stringify(s).length), expected, 'the coordinates should equal the expected')
+  t.end()
+})
+
+test('coordinates - get - number', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'United-Kingdom.txt'), 'utf-8')
+  let sec = wtf(str).section(0)
+
+  t.equal(JSON.stringify(sec.coordinates(0)).length, 70, 'the coordinates should equal the expected')
+  t.end()
+})
+
+test('coordinates - get - number', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'United-Kingdom.txt'), 'utf-8')
+  let sec = wtf(str).section(0)
+
+  t.equal(JSON.stringify(sec.coordinates(54)).length, 2, 'the coordinates should equal the expected')
+  t.end()
+})
+//lists
+test('lists - get', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'United-Kingdom.txt'), 'utf-8')
+  let sec = wtf(str).section('See also')
+
+  const expected = [22]
+  t.deepEqual(sec.lists().map(s => JSON.stringify(s.lines()).length), expected, 'the lists should equal the expected')
+  t.end()
+})
+
+test('lists - get - number', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'United-Kingdom.txt'), 'utf-8')
+  let sec = wtf(str).section('See also')
+
+  t.equal(JSON.stringify(sec.lists(0).lines()).length, 22, 'the lists should equal the expected')
+  t.end()
+})
+
+//interwiki
+
+//images
+test('images - get', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'United-Kingdom.txt'), 'utf-8')
+  let sec = wtf(str).section('Background')
+
+  const expected = [124, 79, 89]
+  t.deepEqual(sec.images().map(s => s.url().length), expected, 'the images should equal the expected')
+  t.end()
+})
+
+test('images - get - number', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'United-Kingdom.txt'), 'utf-8')
+  let sec = wtf(str).section('Background')
+
+  t.equal(sec.images(0).url().length, 124, 'the images should equal the expected')
+  t.end()
+})
+
+test('images - get', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'United-Kingdom.txt'), 'utf-8')
+  let sec = wtf(str).section(0)
+
+  const expected = []
+  t.deepEqual(sec.images().map(s => s.url().length), expected, 'the images should equal the expected')
+  t.end()
+})
+
+//references
+test('references - get', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'United-Kingdom.txt'), 'utf-8')
+  let sec = wtf(str).section(0)
+
+  const expected = [15, 104, 58, 38, 50, 0, 0, 0, 30, 33, 34, 0, 71, 0, 56, 85, 16, 59, 64, 29, 0, 0, 0, 0, 0, 26, 60, 0, 35, 87, 90, 42, 0, 0]
+  t.deepEqual(sec.references().map(s => s.title().length), expected, 'the references should equal the expected')
+  t.end()
+})
+
+test('references - get - number', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'United-Kingdom.txt'), 'utf-8')
+  let sec = wtf(str).section(0)
+
+  t.equal(sec.references(0).title().length, 15, 'the references should equal the expected')
+  t.end()
+})
+//citations -- alias of references
+test('references - get', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'United-Kingdom.txt'), 'utf-8')
+  let sec = wtf(str).section(0)
+
+  const expected = [15, 104, 58, 38, 50, 0, 0, 0, 30, 33, 34, 0, 71, 0, 56, 85, 16, 59, 64, 29, 0, 0, 0, 0, 0, 26, 60, 0, 35, 87, 90, 42, 0, 0]
+  t.deepEqual(sec.citations().map(s => s.title().length), expected, 'the citations should equal the expected')
+  t.end()
+})
+
+test('citations - get - number', (t) => {
+  let str = fs.readFileSync(path.join(__dirname, 'cache', 'United-Kingdom.txt'), 'utf-8')
+  let sec = wtf(str).section(0)
+
+  t.equal(sec.citations(0).title().length, 15, 'the citations should equal the expected')
+  t.end()
+})
+//remove
+
+//nextSibling
+
+//next -- alias of nextSibling
+
+//lastSibling
+
+//last -- alias of lastSibling
+
+//previousSibling -- alias of lastSibling
+
+//previous -- alias of lastSibling
+
+//children
+
+//sections -- alias of lastSibling
+
+//parent
+
+//text
+
+//json
+
+//title
+
+//title

--- a/tests/table.test.js
+++ b/tests/table.test.js
@@ -1,9 +1,9 @@
-var test = require('tape')
-var wtf = require('./lib')
-var readFile = require('./lib/_cachedPage')
+const test = require('tape')
+const wtf = require('./lib')
+const readFile = require('./lib/_cachedPage')
 
 test('bluejays table', t => {
-  var arr = readFile('bluejays').tables(0).data
+  const arr = readFile('bluejays').tables(0).data
   t.equal(arr.length, 8, 'table-length-bluejays')
   t.equal(arr[0]['Level'].text(), 'AAA', 'level-col')
   t.equal(arr[0]['Team'].text(), 'Buffalo Bisons', 'team-col')
@@ -13,16 +13,16 @@ test('bluejays table', t => {
 })
 
 test('rnli stations', t => {
-  var doc = readFile('rnli_stations')
+  const doc = readFile('rnli_stations')
   t.equal(doc.categories().length, 5, 'cat-length')
 
-  var intro = doc.sections(0)
+  const intro = doc.sections(0)
   t.equal(intro.title(), '', 'intro-title')
   t.equal(intro.images().length > 0, true, 'intro-image-length')
   t.equal(intro.sentences().length > 0, true, 'intro-sentence-length')
 
-  var key = doc.sections(1)
-  t.equal(key.depth, 0, 'key-depth')
+  const key = doc.sections(1)
+  t.equal(key._depth, 0, 'key-depth')
   t.equal(key.title(), 'Key', 'key-title')
   t.equal(key.sentences().length, 0, 'key-no-sentences')
   t.deepEqual(key.images(), [], 'key-no-images')
@@ -30,34 +30,35 @@ test('rnli stations', t => {
   t.deepEqual(key.lists(), [], 'key-no-lists')
   t.deepEqual(key.tables(), [], 'key-no-tables')
 
-  var lifeboat = doc.sections(2)
-  t.equal(lifeboat.depth, 1, 'lifeboat-depth')
+  const lifeboat = doc.sections(2)
+  t.equal(lifeboat._depth, 1, 'lifeboat-depth')
   t.equal(lifeboat.templates(0).list[0], 'Royal National Lifeboat Institution lifeboats', 'lifeboat-main')
   t.equal(lifeboat.lists(0).json().length, 3, 'lifeboat-list')
   t.equal(lifeboat.sentences().length, 3, 'lifeboat-sentences')
   t.deepEqual(lifeboat.images(), [], 'lifeboat-no-images')
   t.deepEqual(lifeboat.tables(), [], 'lifeboat-no-tables')
 
-  var east = doc.sections(6)
+  const east = doc.sections(6)
   t.equal(east.title(), 'East Division', 'East Division')
   t.deepEqual(east.images(), [], 'East-no-images')
   t.deepEqual(east.lists(), [], 'East-no-lists')
   t.equal(east.sentences().length, 0, 'east-sentences')
-  var table = east.tables(0).data
+
+  const table = east.tables(0).data
   t.equal(table.length, 42, 'east table-rows')
   t.equal(table[0].Location.text(), 'Hunstanton, Norfolk', 'east-table-data')
   t.equal(table[41]['Launch method'].text(), 'Carriage', 'east-table-data-end')
 
-  var south = doc.sections(7)
-  var sTable = south.tables(0).data
+  const south = doc.sections(7)
+  const sTable = south.tables(0).data
   t.equal(sTable.length, 35, 'south-table-rows')
   t.equal(sTable[0].Location.text(), 'Mudeford, Dorset', 'south-table-data')
   t.end()
 })
 
-// https://en.wikipedia.org/wiki/Help:Table
+//https://en.wikipedia.org/wiki/Help:Table
 test('simple table', t => {
-  var simple = `{| class="wikitable"
+  const simple = `{| class="wikitable"
 |-
 ! Header 1
 ! Header 2
@@ -71,8 +72,8 @@ test('simple table', t => {
 | row 2, cell 2
 | row 2, cell 3
 |}`
-  var obj = wtf(simple)
-  var table = obj.tables(0).data
+  const obj = wtf(simple)
+  const table = obj.tables(0).data
   t.equal(table.length, 2, '2 rows')
   t.equal(table[0]['Header 1'].text(), 'row 1, cell 1', '1,1')
   t.equal(table[0]['Header 2'].text(), 'row 1, cell 2', '1,2')
@@ -84,7 +85,7 @@ test('simple table', t => {
 })
 
 test('multiplication table', t => {
-  var mult = `{| class="wikitable" style="text-align: center; width: 200px; height: 200px;"
+  const mult = `{| class="wikitable" style="text-align: center; width: 200px; height: 200px;"
 |+ Multiplication table
 |-
 ! ×
@@ -107,8 +108,8 @@ test('multiplication table', t => {
 ! 5
 | 5 || 10 || 15
 |}`
-  var obj = wtf(mult)
-  var table = obj.tables(0).data
+  const obj = wtf(mult)
+  const table = obj.tables(0).data
   t.equal(table[0]['1'].text(), '1', '1x1')
   t.equal(table[1]['1'].text(), '2', '1x2')
   t.equal(table[1]['2'].text(), '4', '2x2')
@@ -116,7 +117,7 @@ test('multiplication table', t => {
 })
 
 test('inline-table-test', t => {
-  var inline = `{| class="wikitable"
+  const inline = `{| class="wikitable"
 |+ style="text-align: left;" | Data reported for 2014–2015, by region<ref name="Garcia 2005" />
 |-
 ! scope="col" | Year !! scope="col" | Africa !! scope="col" | Americas !! scope="col" | Asia & Pacific !! scope="col" | Europe
@@ -127,8 +128,8 @@ test('inline-table-test', t => {
 ! scope="row" | 2015
 | 2,725 || ''9,200'' || 8,850 || 4,775
 |}`
-  var obj = wtf(inline)
-  var table = obj.tables(0).data
+  const obj = wtf(inline)
+  const table = obj.tables(0).data
   t.equal(table[0].Year.text(), '2014', 'first year')
   t.equal(table[0].Africa.text(), '2,300', 'africa first-row')
   t.equal(table[0].Americas.text(), '8,950', 'america first-row')
@@ -138,7 +139,7 @@ test('inline-table-test', t => {
 
 test('floating-tables-test', t => {
   //we don't (and probably can't) fully support this rn
-  var floating = `{| class="wikitable floatright"
+  const floating = `{| class="wikitable floatright"
 | Col 1, row 1
 | rowspan="2" | Col 2, row 1 (and 2)
 | Col 3, row 1
@@ -154,16 +155,16 @@ test('floating-tables-test', t => {
 | Col 1, row 2
 | Col 3, row 2
 |}`
-  var obj = wtf(floating)
+  const obj = wtf(floating)
   t.equal(obj.tables().length, 2, 'two tables')
-  var table = obj.tables(0).data
+  const table = obj.tables(0).data
   t.equal(table[0]['col1'].text(), 'Col 1, row 1', '1,1')
   t.end()
 })
 
 test('wikisortable-tables-test', t => {
   //we don't (and probably can't) fully support this rn
-  var sortable = `{| class="wikitable sortable"
+  const sortable = `{| class="wikitable sortable"
 |+ Sortable table
 |-
 ! scope="col" | Alphabetic
@@ -181,9 +182,9 @@ test('wikisortable-tables-test', t => {
 |-
 | e || 0 || 1601-08-13 || sorted.
 |}`
-  var obj = wtf(sortable)
+  const obj = wtf(sortable)
   t.equal(obj.tables().length, 1, 'one table')
-  var table = obj.tables(0).data
+  const table = obj.tables(0).data
   t.equal(table[0]['Alphabetic'].text(), 'd', '1,1')
   t.equal(table[0]['Numeric'].text(), '20', '1,2')
   t.equal(table[0]['Date'].text(), '2008-11-24', '1,3')
@@ -196,7 +197,7 @@ test('wikisortable-tables-test', t => {
 })
 
 test('messy-table-test', t => {
-  var messy = ` {| class="wikitable"
+  const messy = ` {| class="wikitable"
      |[[File:Worms 01.jpg|199x95px]]
       |[[File:Worms Wappen 2005-05-27.jpg|199x95px]]
   |<!--col3-->[[File:Liberty-statue-with-manhattan.jpg|199x95px]]
@@ -209,16 +210,16 @@ test('messy-table-test', t => {
   |Statue of Liberty
   |New York City
  |}`
-  var obj = wtf(messy)
-  var table = obj.tables(0).json()
+  const obj = wtf(messy)
+  const table = obj.tables(0).json()
   t.equal(table[1]['col1'].text, 'Nibelungen Bridge to Worms', 'col1 text')
-  // var keyVal=obj.tables(0).keyValue()
-  // t.equal()
+  //const keyVal=obj.tables(0).keyValue()
+  //t.equal()
   t.end()
 })
 
 test('embedded-table', t => {
-  var str = ` {|
+  const str = ` {|
   | one
   | two
   | three
@@ -233,7 +234,7 @@ test('embedded-table', t => {
   |[[Chicago]]
   |}
   `
-  var tables = wtf(str).tables()
+  const tables = wtf(str).tables()
   t.equal(tables.length, 2, 'found both tables')
   t.equal(tables[0].links().length, 1, 'found one link')
   t.equal(tables[1].links().length, 1, 'found another link')
@@ -241,7 +242,7 @@ test('embedded-table', t => {
 })
 
 test('embedded-table-2', t => {
-  var str = ` {| class="oopsie"
+  const str = ` {| class="oopsie"
   | first row
   |-
   | Secod row
@@ -257,15 +258,15 @@ test('embedded-table-2', t => {
   |}
 
   Actual first sentence is here`
-  var doc = wtf(str)
+  const doc = wtf(str)
   t.equal(doc.tables().length, 2, 'found both tables')
-  var text = doc.sentences(0).text()
+  const text = doc.sentences(0).text()
   t.equal('Actual first sentence is here', text, 'got proper first sentence')
   t.end()
 })
 
 test('sortable table', t => {
-  var str = `{|class="wikitable sortable"
+  const str = `{|class="wikitable sortable"
   !Name and Surname!!Height
   |-
   |data-sort-value="Smith, John"|John Smith||1.85
@@ -276,15 +277,15 @@ test('sortable table', t => {
   |-
   !Average:||1.82
   |}`
-  var doc = wtf(str)
-  var row = doc.tables(0).data[0]
+  const doc = wtf(str)
+  const row = doc.tables(0).data[0]
   t.equal(row.Height.text(), '1.85', 'got height')
   t.equal(row['Name and Surname'].text(), 'John Smith', 'got name')
   t.end()
 })
 
 test('missing-row test', t => {
-  var str = `{|class="wikitable"
+  const str = `{|class="wikitable"
   |-
   ! style="background:#ddf; width:0;"| #
   ! style="background:#ddf; width:11%;"| Date
@@ -306,14 +307,14 @@ test('missing-row test', t => {
   |-align="center" bgcolor="bbffbb"
   |}
   Actual first sentence  is here`
-  var row = wtf(str).tables(0).data[0]
+  const row = wtf(str).tables(0).data[0]
   t.equal(row.Save.text(), '', 'got empty property')
   t.equal(row.Record.text(), '2–0', 'got last property')
   t.end()
 })
 
 test('table newline removal', t => {
-  var str = `hello this is the top
+  const str = `hello this is the top
 {| class="wikitable" style="font-size: 95%;"
 | 1
 | [[Daugpiļs]]
@@ -325,13 +326,13 @@ test('table newline removal', t => {
 | [[Rēzne]]
 |}
 `
-  var doc = wtf(str)
+  const doc = wtf(str)
   t.equal(doc.text(), 'hello this is the top', 'text on top')
   t.end()
 })
 
 test('table rowspan', t => {
-  var str = `{| class="wikitable"
+  const str = `{| class="wikitable"
 | rowspan="2"| one
 | two
 | three
@@ -339,8 +340,8 @@ test('table rowspan', t => {
 | two B
 | three B
 |}`
-  var doc = wtf(str)
-  var table = doc.tables(0).keyValue()
+  const doc = wtf(str)
+  const table = doc.tables(0).keyValue()
   t.equal(table[0].col1, 'one', 'has init')
   t.equal(table[1].col1, 'one', 'has copy')
   t.equal(table[0].col2, 'two', 'has later')
@@ -351,7 +352,7 @@ test('table rowspan', t => {
 })
 
 test('table colspan', t => {
-  var str = `{| class="wikitable"
+  const str = `{| class="wikitable"
 | colspan="2" style="text-align:center;"| one/two
 | three
 |-
@@ -359,8 +360,8 @@ test('table colspan', t => {
 | two B
 | three B
 |}`
-  var doc = wtf(str)
-  var table = doc.tables(0).keyValue()
+  const doc = wtf(str)
+  const table = doc.tables(0).keyValue()
   t.equal(table[0].col1, 'one/two', 'has init')
   t.equal(table[0].col2, '', 'has empty span')
   t.equal(table[0].col3, 'three', 'has after span')
@@ -373,7 +374,7 @@ test('table colspan', t => {
 
 //use first row as the table header
 test('first-row as header', t => {
-  var simple = `{| class="wikitable"
+  const simple = `{| class="wikitable"
 |-
 | Name
 | Country
@@ -387,8 +388,8 @@ test('first-row as header', t => {
 |-
 | may || sweden || caption
 |}`
-  var obj = wtf(simple)
-  var table = obj.tables(0).json()
+  const obj = wtf(simple)
+  const table = obj.tables(0).json()
   t.equal(table.length, 4, '4 rows')
   t.equal(table[0]['name'].text, 'spencer', 'got name 1')
   t.equal(table[0]['country'].text, 'canada', 'got country 1')
@@ -399,7 +400,7 @@ test('first-row as header', t => {
 
 //two-row header composite
 test('two-rows as header', t => {
-  var str = `{| class="wikitable"
+  const str = `{| class="wikitable"
   |-
   ! A
   ! B
@@ -414,7 +415,7 @@ test('two-rows as header', t => {
   |-
   | a || b || c || d || e
   |}`
-  var table = wtf(str)
+  const table = wtf(str)
     .tables(0)
     .keyValue()
   t.equal(table.length, 1, '1 row')
@@ -426,7 +427,7 @@ test('two-rows as header', t => {
 
 //two-row header with spans
 test('two-header-rows-with-spans', t => {
-  var str = `{| class="wikitable"
+  const str = `{| class="wikitable"
   |-
   ! A
   ! B
@@ -440,7 +441,7 @@ test('two-header-rows-with-spans', t => {
   |-
   | a || b || c || d || e
   |}`
-  var table = wtf(str)
+  const table = wtf(str)
     .tables(0)
     .keyValue()
   t.equal(table.length, 1, '1 row')
@@ -453,7 +454,7 @@ test('two-header-rows-with-spans', t => {
 
 //nfl football table
 test('junky-table', t => {
-  var str = `{| class="navbox plainrowheaders wikitable" style="width:100%"
+  const str = `{| class="navbox plainrowheaders wikitable" style="width:100%"
 ! A
 ! B
 ! C
@@ -470,7 +471,7 @@ test('junky-table', t => {
 |[[Hard Rock Stadium]]
 |-
 |}`
-  var table = wtf(str)
+  const table = wtf(str)
     .tables(0)
     .keyValue()
   t.equal(table.length, 2, '2 row2')
@@ -482,7 +483,7 @@ test('junky-table', t => {
 })
 
 test('table double bar', t => {
-  var str = `{| class="wikitable"
+  const str = `{| class="wikitable"
 |-
 ! h1
 ! h2
@@ -498,8 +499,8 @@ test('table double bar', t => {
 || cc
 || ccc
 |}`
-  var doc = wtf(str)
-  var data = doc.tables(0).keyValue()
+  const doc = wtf(str)
+  const data = doc.tables(0).keyValue()
   t.equal(data[0].h1, 'a', 'h1')
   t.equal(data[0].h2, 'aa', 'h2')
   t.equal(data[0].h3, 'aaa', 'h3')
@@ -514,7 +515,7 @@ test('table double bar', t => {
 
 //testing https://github.com/spencermountain/wtf_wikipedia/issues/332
 test('table newline', t => {
-  var str = `{| class="wikitable"
+  const str = `{| class="wikitable"
 |-
 ! h1
 ! h2
@@ -529,8 +530,8 @@ test('table newline', t => {
 b2
 | c
 |}`
-  var doc = wtf(str)
-  var data = doc.tables(0).keyValue()
+  const doc = wtf(str)
+  const data = doc.tables(0).keyValue()
   t.equal(data[0].h1, 'a', 'h1')
   t.equal(data[0].h2, 'b1 b2', 'h2')
   t.equal(data[0].h3, 'c', 'h3')

--- a/tests/types/tsconfig.json
+++ b/tests/types/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",
-    "lib": [],
+    "lib": [ ],
     "allowJs": true,
     "checkJs": true,
     "declaration": true,

--- a/ts-doc-config.json
+++ b/ts-doc-config.json
@@ -1,0 +1,21 @@
+{
+  "recurseDepth": 10,
+  "source": {
+    "includePattern": ".+\\.js(doc|x)?$"
+  },
+  "sourceType": "module",
+  "tags": {
+    "allowUnknownTags": true,
+    "dictionaries": [ "jsdoc", "closure" ]
+  },
+  "templates": {
+    "cleverLinks": false,
+    "monospaceLinks": false
+  },
+  "plugins": [ "./node_modules/tsd-jsdoc/dist/plugin" ],
+  "opts": {
+    "template": "./node_modules/tsd-jsdoc/dist",
+    "recurse": true,
+    "destination": "./builds/"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,77 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+     "lib": ["ES6", "DOM"],                   /* Specify library files to be included in the compilation. */
+     "allowJs": true,                         /* Allow javascript files to be compiled. */
+     "checkJs": true,                         /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+     "noEmit": true,                          /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    "noImplicitAny": false,                   /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+     "noUnusedLocals": true,                /* Report errors on unused locals. */
+     "noUnusedParameters": true,            /* Report errors on unused parameters. */
+     "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+     "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
+    "forceConsistentCasingInFileNames": true,  /* Disallow inconsistently-cased references to the same file. */
+  },
+  "include": [
+    "src/**/*.js",
+    "plugins/**/*.js"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/node_modules/*"
+  ]
+}


### PR DESCRIPTION
hello,

the first part of PR is the result of some procrasti-working (procrastination and working) and the second part is doing the same to section as I did to document

**worked on the fetch lib**
added jsdocs 
simplified the overloads
documented some of the options in jsdoc types

**added some more typescript infrastructure**
because typescript, type generation, auto complete, vs code and jsdoc are very closely related i thought it would be handy to have maybe some more typescript stuff

This commit adds `tsconfig.json` which controls how typescript works on this repo. currently i have it configured as a type checking tool for the js files.

I also added a config for type generation this bings it one step closer to replacing the static types.

this is one of my more controversial commits so i'm happy to remove it if you ask so

**cleaned template parsing somewhat and split out some helper functions**
more jsdocs, eslint fixes and dry programming 

**refactored Sections to es classes**
adding more tests for section
refactoring the section class 
fixing the test afterwards


This PR is not done jet I still need to add jsdoc to the sections class

-wvanderp



