### PR TITLE
Handling unbulleted list templates consistently

### DIFF
--- a/src/template/custom/aliases.js
+++ b/src/template/custom/aliases.js
@@ -48,11 +48,22 @@ let multi = {
 
   nihongo: ['nihongo2', 'nihongo3', 'nihongo-s', 'nihongo foot'],
 
-  plainlist: ['flatlist', 'ublist', 'plain list'],
+  plainlist: ['flatlist', 'plain list'],
 
   'winning percentage': ['winpct', 'winperc'],
 
-  'collapsible list': ['unbulleted list', 'ubl'],
+  'collapsible list': [
+    'nblist',
+    'nonbulleted list',
+    'ubl',
+    'ublist',
+    'ubt',
+    'unbullet',
+    'unbulleted list',
+    'unbulleted',
+    'unbulletedlist',
+    'vunblist'
+  ],
 
   'election box begin': [
     'election box begin no change',

--- a/tests/integration/more-templates.test.js
+++ b/tests/integration/more-templates.test.js
@@ -118,3 +118,33 @@ test('austria-hungary', (t) => {
   )
   t.end()
 })
+
+test('collapsible list', (t) => {
+  const str = `{{ubl|a|b}}`
+  const doc = wtf(str)
+  console.log(doc)
+  console.log(doc.template())
+  const obj = doc.template().json()
+  t.equal(obj.template, 'ubl', 'name')
+  t.equal(obj.list[0], 'a', 'list1')
+  t.equal(obj.list[1], 'b', 'list2')
+  t.equal(obj.list.length, 2, 'list-len')
+
+  //now sanity check all aliases
+  const testText = (template) => {
+    let actual = wtf(`{{${template}|a|b}}`).text().replace(/[\n]+/, ' ')
+    t.equal(actual, 'a b', template)
+  }
+  testText('collapsible list')
+  testText('ubl')
+  testText('unbullet')
+  testText('ubt')
+  testText('vunblist')
+  testText('ublist')
+  testText('unbulletedlist')
+  testText('unbulleted list')
+  testText('unbulleted')
+  testText('nblist')
+  testText('nonbulleted list')
+  t.end()
+})


### PR DESCRIPTION
The various shortcuts for the unbulleted list template are now handled consistently (by aliasing them to `collapsible list` which seems to provide the required behaviour).

Closes #433.