### PR TITLE
cli.js: fix args definition

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 const wtf = require('./src/index')
-const args = process.argv.slice(2)
+let args = process.argv.slice(2)
 
 const modes = {
   '--json': 'json',


### PR DESCRIPTION
running cli.js crashes as `args` is reassigned