### PR TITLE
Typescript 4.4: Refer to typeof fetch, not the value fetch

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -212,7 +212,7 @@ declare namespace wtf {
 
 declare function extend(fn: Function): {
   (wiki: string, options: object): Document
-  fetch: fetch
+  fetch: typeof fetch
   extend: typeof extend
   plugin: typeof extend
   version: string


### PR DESCRIPTION
Typescript 4.4.4 reports:
```
Error: node_modules/wtf_wikipedia/types/index.d.ts:215:10 - error TS2749: 'fetch' refers to a value, but is being used as a type here. Did you mean 'typeof fetch'?
```
