### PR TITLE
fixed interwiki parsing bug and added tests

### DIFF
--- a/src/link/interwiki.js
+++ b/src/link/interwiki.js
@@ -22,7 +22,7 @@ const parseInterwiki = function (obj) {
     if (site.indexOf(':') !== -1) {
       let [, wiki, lang] = site.match(/^:?(.*):(.*)/)
       //only allow interwikis to these specific places
-      if (interwikis.hasOwnProperty(wiki) && languages.hasOwnProperty(lang) === false) {
+      if (interwikis.hasOwnProperty(wiki) === false || languages.hasOwnProperty(lang) === false) {
         return obj
       }
       obj.wiki = { wiki: wiki, lang: lang }

--- a/tests/integration/interwiki.test.js
+++ b/tests/integration/interwiki.test.js
@@ -29,6 +29,21 @@ test('expand external interwiki link', (t) => {
   t.equal(obj.text, 'bonjour', 'text')
   t.deepEqual(obj.wiki, { wiki: 'wiktionary', lang: 'fr' }, 'wiki')
 
+  str = `[[ThisIsNotAWiki:text]]`
+  doc = wtf(str)
+  obj = doc.link().json()
+  t.notEqual(obj.type, 'interwiki')
+
+  str = `[[ThisIsNotAWiki:en:text]]`
+  doc = wtf(str)
+  obj = doc.link().json()
+  t.notEqual(obj.type, 'interwiki')
+
+  str = `[[wikipedia:ThisIsNotALanguage:text]]`
+  doc = wtf(str)
+  obj = doc.link().json()
+  t.notEqual(obj.type, 'interwiki')
+
   t.end()
 })
 


### PR DESCRIPTION
#379 introduced a bug where `[[some text: more text: even more text]]` (as seen in the wild [here](https://starwars.fandom.com/wiki/Starlight:_Part_One:_Go_Together)) gets interpreted as an interwiki link when it shouldn't.