### PR TITLE
fixed table parsing bugs

### DIFF
--- a/src/table/parse/_findRows.js
+++ b/src/table/parse/_findRows.js
@@ -31,14 +31,18 @@ const findRows = function (lines) {
         row = []
       }
     } else {
+      // remove leading | or ! for the ||/!! splitting
+      let startChar = line.charAt(0)
+      if (startChar === '|' || startChar === '!') {
+        line = line.substring(1)
+      }
       //look for '||' inline row-splitter
       line = line.split(/(?:\|\||!!)/) //eslint-disable-line
-      //support newline -> '||'
-      if (!line[0] && line[1]) {
-        line.shift()
+      // add leading ! back, because we later read it in header parsing functions
+      if (startChar === '!') {
+        line[0] = startChar + line[0]
       }
       line.forEach((l) => {
-        l = l.replace(/^\| */, '')
         l = l.trim()
         row.push(l)
       })

--- a/src/table/parse/index.js
+++ b/src/table/parse/index.js
@@ -22,7 +22,7 @@ const cleanText = function (str) {
   str = parseSentence(str).text()
   //anything before a single-pipe is styling, so remove it
   if (str.match(/\|/)) {
-    str = str.replace(/.+?\| ?/, '') //class="unsortable"|title
+    str = str.replace(/.*?\| ?/, '') //class="unsortable"|title
   }
   str = str.replace(/style=['"].*?["']/, '')
   //'!' is used as a highlighed-column

--- a/src/table/parse/index.js
+++ b/src/table/parse/index.js
@@ -22,7 +22,7 @@ const cleanText = function (str) {
   str = parseSentence(str).text()
   //anything before a single-pipe is styling, so remove it
   if (str.match(/\|/)) {
-    str = str.replace(/.+\| ?/, '') //class="unsortable"|title
+    str = str.replace(/.+?\| ?/, '') //class="unsortable"|title
   }
   str = str.replace(/style=['"].*?["']/, '')
   //'!' is used as a highlighed-column

--- a/tests/integration/table.test.js
+++ b/tests/integration/table.test.js
@@ -538,8 +538,49 @@ b2
 test('multiple pipes in a cell', (t) => {
   const str = `{|
   | styling | content | more content
+  |-
+  || content | more content
   |}`
   const table = wtf(str).table(0).keyValue()
   t.equal(table[0].col1, 'content | more content', 'col1')
+  t.equal(table[1].col1, 'content | more content', 'col1 row2')
+  t.end()
+})
+
+test('empty cells', (t) => {
+  // Actually rendered table:
+  // A | B | C | D |   | F |   |   | I |   | K
+  //   | b |   | d | e | f | g | h | i | j | k
+  //   |   | c |   | e
+  const str = `{| class="wikitable"
+  ! A
+  ! B
+  ! C
+  ! D
+  !!! F
+  !!!!! I !!!! K
+  |-
+  ||| b |||| d || e || f || g || h || i || j || k
+  |-
+  ||||| c
+  |||| e
+  |}`
+  const table = wtf(str).table(0).keyValue()
+  t.equal(table[0].A, '', 'a1')
+  t.equal(table[0].B, 'b', 'b1')
+  t.equal(table[0].C, '', 'c1')
+  t.equal(table[0].D, 'd', 'd1')
+  t.equal(table[0].col5, 'e', 'e1')
+  t.equal(table[0].F, 'f', 'f1')
+  t.equal(table[0].col7, 'g', 'g1')
+  t.equal(table[0].col8, 'h', 'h1')
+  t.equal(table[0].I, 'i', 'i1')
+  t.equal(table[0].col10, 'j', 'j1')
+  t.equal(table[0].K, 'k', 'k1')
+  t.equal(table[1].A, '', 'a2')
+  t.equal(table[1].B, '', 'b2')
+  t.equal(table[1].C, 'c', 'c2')
+  t.equal(table[1].D, '', 'd2')
+  t.equal(table[1].col5, 'e', 'e2')
   t.end()
 })

--- a/tests/integration/table.test.js
+++ b/tests/integration/table.test.js
@@ -534,3 +534,12 @@ b2
   t.equal(data[0].h3, 'c', 'h3')
   t.end()
 })
+
+test('multiple pipes in a cell', (t) => {
+  const str = `{|
+  | styling | content | more content
+  |}`
+  const table = wtf(str).table(0).keyValue()
+  t.equal(table[0].col1, 'content | more content', 'col1')
+  t.end()
+})


### PR DESCRIPTION
This fixes two bugs.
First was incorrectly parsing multiple pipes in a cell: `| styling | content | more content, the pipe is just part of the content`. The greedy regex would eat everything until the last pipe instead of just up to the first one
Second bug was the parsing of `|||` at the start of line which is basically an empty cell, but the parser would skip it so if we had:
```
column1  | column2
         | cell2
```
cell2 would be parsed as part of column1 instead of column2.

Also should this be 2 separate PRs or is this fine?