### PR TITLE
refactor: move `file()`-related code to `Image.js`

### DIFF
--- a/src/image/Image.js
+++ b/src/image/Image.js
@@ -27,7 +27,15 @@ const Image = function (data) {
 
 const methods = {
   file() {
-    return this.data.file || ''
+    let file = this.data.file || ''
+    if (file) {
+      file = file.trim()
+      //titlecase it
+      file = file.charAt(0).toUpperCase() + file.substring(1)
+      //spaces to underscores
+      file = file.replace(/ /g, '_')
+    }
+    return file
   },
   alt() {
     let str = this.data.alt || this.data.file || ''

--- a/src/image/index.js
+++ b/src/image/index.js
@@ -33,11 +33,6 @@ const oneImage = function (img, doc) {
     return null
   }
   let file = `${m[1]}:${m[2] || ''}`
-  file = file.trim()
-  //titlecase it
-  file = file.charAt(0).toUpperCase() + file.substring(1)
-  //spaces to underscores
-  file = file.replace(/ /g, '_')
   if (file) {
     let obj = {
       file: file,

--- a/src/infobox/Infobox.js
+++ b/src/infobox/Infobox.js
@@ -47,11 +47,6 @@ const methods = {
     }
     let obj = s.json()
     let file = obj.text
-    file = file.trim()
-    //titlecase it
-    file = file.charAt(0).toUpperCase() + file.substring(1)
-    //spaces to underscores
-    file = file.replace(/ /g, '_')
     file = `File:${file}`
     obj.file = file
     obj.text = ''


### PR DESCRIPTION
`Image` is used in several places and some of them like [here](https://github.com/spencermountain/wtf_wikipedia/blob/e702419c8ac8bb2b16965a46e3ac3b52b218ddcf/src/01-document/Document.js#L326) lack this piece of code so I moved the code to `Image.js` and deleted the rest