### PR TITLE
Fix getCategory always using default options

### DIFF
--- a/plugins/api/src/getCategory.js
+++ b/plugins/api/src/getCategory.js
@@ -46,7 +46,7 @@ const getCategory = async function (title, options, http) {
   let getMore = true
   let append = ''
   while (getMore) {
-    let url = makeUrl(title, defaults, append)
+    let url = makeUrl(title, options, append)
     let { pages, cursor } = await fetchIt(url, http, 'categorymembers')
     list = list.concat(pages)
     if (cursor && cursor.cmcontinue) {


### PR DESCRIPTION
When `getCategory` was called, `options` were ignored and `defaults` were used.