### PR TITLE
getCategoryPages now returns subcategories

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,22 +359,27 @@ the fetch method follows redirects.
 
 ### API plugin
 
-**wtf.category(title, [lang], [options | callback])**
+**wtf.getCategoryPages(title, [options])**
 
 retrieves all pages and sub-categories belonging to a given category:
 
 ```js
 wtf.extend(require('wtf-plugin-api'))
-let result = await wtf.category('Category:Politicians_from_Paris')
+let result = await wtf.getCategoryPages('Category:Politicians_from_Paris')
 /*
 {
-  pages: [{title: 'Paul Bacon', pageid: 1266127 }, ...],
-  categories: [ {title: 'Category:Mayors of Paris' } ]
+  [
+    {"pageid":52502362,"ns":0,"title":"William Abitbol"},
+    {"pageid":50101413,"ns":0,"title":"Marie-Joseph Charles des Acres de L'Aigle"}
+    ...
+    {"pageid":62721979,"ns":14,"title":"Category:Councillors of Paris"},
+    {"pageid":856891,"ns":14,"title":"Category:Mayors of Paris"}
+  ]
 }
 */
 ```
 
-**wtf.random([lang], [options], [callback])**
+**wtf.random([options])**
 
 fetches a random wikipedia article, from a given language or domain
 

--- a/plugins/api/README.md
+++ b/plugins/api/README.md
@@ -125,14 +125,17 @@ wtf.getRandomCategory({lang:'fr'}).then(cat=>{
 ```
 
 ## Category Pages
-fetch+parse all documents in a given category, to a specific depth.
+fetch all documents and sub-categories in a given category. Only returns identifying information for the page, not the actual page content.
 ```js
 // get the first sentence of all MLB stadiums:
-wtf.getCategoryPages('Major League Baseball venues').then(docs => {
-  docs.map(doc => doc.sentence(0).text())
+wtf.getCategoryPages('Major League Baseball venues').then(pages => {
+  pages.map(page => page.title)
   // [
-  //  'Fenway park is a sports complex and major league baseball stadium...',
-  //  'Rogers Center is a entertainment venue ...'
+  //  'List of current Major League Baseball stadiums',
+  //  'List of former Major League Baseball stadiums'
+  //  ...
+  //  'Category:Spring training ballparks',
+  //  'Category:Wrigley Field'
   //]
 })
 ```

--- a/plugins/api/src/getCategory.js
+++ b/plugins/api/src/getCategory.js
@@ -5,7 +5,7 @@ const params = {
   list: 'categorymembers',
   cmlimit: 500,
   cmtype: 'page|subcat',
-  cmnamespace: 0,
+  cmnamespace: '0|14',
   format: 'json',
   origin: '*',
   redirects: true
@@ -51,7 +51,7 @@ const getCategory = async function (title, options, http) {
     let { pages, cursor } = await fetchIt(url, http, 'categorymembers')
     list = list.concat(pages)
     if (cursor && cursor.cmcontinue) {
-      append = '&cmcontinue=' + cursor.lhcontinue
+      append = '&cmcontinue=' + cursor.cmcontinue
     } else {
       getMore = false
     }

--- a/plugins/api/tests/category.test.js
+++ b/plugins/api/tests/category.test.js
@@ -2,12 +2,15 @@ import test from 'tape'
 import wtf from './_lib.js'
 
 test('category', (t) => {
-  t.plan(1)
-  const p = wtf.getCategoryPages('Category:Basketball teams in Toronto', {
+  t.plan(2)
+  const p = wtf.getCategoryPages('Category:Politicians_from_Paris', {
     'Api-User-Agent': 'wtf_wikipedia test script - <spencermountain@gmail.com>'
   })
   p.then(function (pages) {
-    t.ok(pages.length > 2, 'got some pages')
+    let realPages = pages.filter(page => !page.title.startsWith('Category:'))
+    let subcategories = pages.filter(page => page.title.startsWith('Category:'))
+    t.ok(realPages.length > 2, 'got some actual real pages')
+    t.ok(subcategories.length > 2, 'got some sub-categories')
   })
   p.catch(function (e) {
     t.throw(e)


### PR DESCRIPTION
From the doc changes it looks like I'm significantly changing the API - I'm not, I'm just changing the doc to what the code currently does (or at least, as far as I can tell).

Note for these changes to work locally required #522, for me at least.

Closes #521.