### PR TITLE
Make references output correctly in markdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wtf_wikipedia",
-  "version": "10.1.4",
+  "version": "10.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wtf_wikipedia",
-      "version": "10.1.4",
+      "version": "10.1.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/plugins/markdown/src/01-doc.js
+++ b/plugins/markdown/src/01-doc.js
@@ -41,7 +41,7 @@ const toMarkdown = function (options) {
   if (options.references === true) {
     md += '## References'
     md += this.citations()
-      .map((c) => c.json(options))
+      .map((c) => c.markdown(options))
       .join('\n')
   }
   return md

--- a/plugins/markdown/tests/markdown.test.js
+++ b/plugins/markdown/tests/markdown.test.js
@@ -48,3 +48,23 @@ test('markdown-tricks', (t) => {
 
   t.end()
 })
+
+test('handles references', (t) => {
+  const md = wtf(`
+  <ref>{{cite web
+    | last = fake
+    | title = Fake reference title
+    | url=http://example.com/fake/ref
+    | accessdate = 2023-09-14 }}</ref>
+
+  == References ==
+  {{ref-list}}
+  `).markdown({references: true})
+  
+  t.equal(md, "== References ==## References⌃ [Fake reference title](http://example.com/fake/ref)", "supports markdown")
+  t.equal(md, md, "supports markdown");
+
+  
+  t.end()
+})
+


### PR DESCRIPTION
Fixes a bug where ``.markdown({references: true})`` would output:

```md
## References
[object Object]
```

Fix was moving from .json to .markdown