### PR TITLE
Fix for invalid JSON data :hammer:

### DIFF
--- a/src/_fetch/index.js
+++ b/src/_fetch/index.js
@@ -68,6 +68,9 @@ const fetch = function (title, options, callback) {
   return unfetch(url, headers)
     .then((res) => res.json())
     .then((res) => {
+      if (!res){
+        throw new Error(`No JSON Data Found For ${url}`)
+      }
       let data = getResult(res, options)
       data = parseDoc(data, title)
       if (callback) {


### PR DESCRIPTION
This PR will NOW close issue [#246](https://github.com/spencermountain/wtf_wikipedia/issues/547).

Throwing / handling this error. 
```js
Un-handled Errors:

/node_modules/wtf_wikipedia/src/_fetch/index.js:71:18
TypeError: Cannot convert undefined or null to object
```

Same as before, but should pass build testing :blush: - *my bad*.