### PR TITLE
Fix for Page ID not found :hammer:

### DIFF
--- a/src/_fetch/getResult.js
+++ b/src/_fetch/getResult.js
@@ -9,6 +9,11 @@
  * @returns {*} result
  */
 const getResult = function (data, options = {}) {
+  // handle nothing found or no data passed
+  if(!data?.query?.pages || !data?.query || !data){
+     return null
+  }
+  
   //get all the pagesIds from the result
   let pages = Object.keys(data.query.pages)
 


### PR DESCRIPTION
This PR adds a null statement to handle an error being throw when no page ID's are found.