### PR TITLE
Exporting types

### DIFF
--- a/builds/wtf_wikipedia.cjs
+++ b/builds/wtf_wikipedia.cjs
@@ -1995,7 +1995,7 @@
   const anyChar = '\\s\\S'; //including newline
   const noThanks = new RegExp(`${openTag}[${anyChar}]+?${closeTag}`, 'gi');
 
-  const kill_xml = function(wiki) {
+  const kill_xml = function (wiki) {
     //(<ref> tags are parsed in Section class) - luckily, refs can't be recursive.
     //types of html/xml that we want to trash completely.
     wiki = wiki.replace(noThanks, ' ');

--- a/builds/wtf_wikipedia.mjs
+++ b/builds/wtf_wikipedia.mjs
@@ -1991,7 +1991,7 @@ const closeTag = `< ?/ ?(${ignore$1.join('|')}) ?>`;
 const anyChar = '\\s\\S'; //including newline
 const noThanks = new RegExp(`${openTag}[${anyChar}]+?${closeTag}`, 'gi');
 
-const kill_xml = function(wiki) {
+const kill_xml = function (wiki) {
   //(<ref> tags are parsed in Section class) - luckily, refs can't be recursive.
   //types of html/xml that we want to trash completely.
   wiki = wiki.replace(noThanks, ' ');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wtf_wikipedia",
-  "version": "10.1.5",
+  "version": "10.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wtf_wikipedia",
-      "version": "10.1.5",
+      "version": "10.1.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/plugins/classify/package-lock.json
+++ b/plugins/classify/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wtf-plugin-classify",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wtf-plugin-classify",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "21.0.3",

--- a/plugins/markdown/package-lock.json
+++ b/plugins/markdown/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wtf-plugin-markdown",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wtf-plugin-markdown",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "21.0.3",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -208,6 +208,17 @@ declare namespace wtf {
   export { extend }
   export { extend as plugin }
   export { version }
+  export { Document }
+  export { Section }
+  export { Infobox }
+  export { Template }
+  export { Table }
+  export { Reference }
+  export { Paragraph }
+  export { Image }
+  export { Link }
+  export { List }
+  export { Sentence }
 }
 
 declare function extend(fn: Function): {


### PR DESCRIPTION
It is very hard to develop using TypeScript without types for `Document`, `Section` and other types. So i exported those types from `/types/index.d.ts`.
Ran all tests and also tried it in my project, all seems fine. 