### PR TITLE
Add support for revisionID

### DIFF
--- a/src/01-document/Document.js
+++ b/src/01-document/Document.js
@@ -48,6 +48,7 @@ class Document {
       // userAgent is used for successive calls to the API
       userAgent: options.userAgent || options['User-Agent'] || options['Api-User-Agent'] || 'User of the wtf_wikipedia library',
       templateFallbackFn: options.templateFallbackFn || null,
+      revisionID: options.revisionID || null,
     }
     // this._missing_templates = {} //for stats+debugging purposes
 
@@ -499,6 +500,20 @@ class Document {
       console.log(indent + (sec.title() || '(Intro)'))
     })
     return this
+  }
+
+  /**
+   * If a revisionID is given then it sets the revisionID and returns the given revisionID
+   * Else if the revisionID is already set it returns the revisionID
+   *
+   * @param {number} [id] The revisionID that will be set
+   * @returns {number|null} The given or found revisionID
+   */
+  revisionID(id) {
+    if (id !== undefined) {
+      this._revisionID = id
+    }
+    return this._revisionID || null
   }
 
   options() {

--- a/tests/integration/Document.test.js
+++ b/tests/integration/Document.test.js
@@ -56,6 +56,26 @@ test('pageID - get / set - if the pageID is set then it should return the same '
   t.end()
 })
 
+//revisionID
+test('revisionID - get - should initially be null', (t) => {
+  let doc = wtf('')
+  t.equal(doc.revisionID(), null, 'the revisionID equals null')
+  t.end()
+})
+
+test('revisionID - get - if the revisionID is already set than get it from internal object', (t) => {
+  let doc = wtf('', { revisionID: 1 })
+  t.equal(doc.revisionID(), 1, 'the revisionID equals 1')
+  t.end()
+})
+
+test('revisionID - get / set - if the revisionID is set then it should return the same ', (t) => {
+  let doc = wtf('')
+  doc.revisionID(1)
+  t.equal(doc.revisionID(), 1, 'the revisionID equals 1')
+  t.end()
+})
+
 //wikidata
 test('wikidata - get - should initially be null', (t) => {
   let doc = wtf('')


### PR DESCRIPTION
This change adds initial support for revisionID as passed in through options. This is useful because one can use this to check for revision changes between two wikipedia dumps, like when using dumpster-dip on a monthly basis to keep a search database up-to-date (for RAG for example).

Mostly I just missed having this, and I plan to submit a follow-up PR to dumpster-dip to have it parse the revisionID and pass it in so I can use it.

Note that this change does not include updating the README and types yet, I will do that, but I wanted to wait for feedback on naming etc. first.