### PR TITLE
Fix incorrect representation of English flag

### DIFF
--- a/src/_data/flags.js
+++ b/src/_data/flags.js
@@ -253,7 +253,7 @@ export default [
   ['🇿🇼 ', 'zwe', 'zimbabwe'],
   //others (later unicode versions)
   ['🇺🇳', 'un', 'united nations'],
-  ['🏴󠁧󠁢󠁥󠁮󠁧󠁿󠁧󠁢󠁥󠁮󠁧󠁿', 'eng', 'england'],
+  ['🏴󠁧󠁢󠁥󠁮󠁧󠁿', 'eng', 'england'],
   ['🏴󠁧󠁢󠁳󠁣󠁴󠁿', 'sct', 'scotland'],
   ['🏴󠁧󠁢󠁷󠁬󠁳󠁿', 'wal', 'wales'],
   ['🇪🇺', 'eu', 'european union'],


### PR DESCRIPTION
```
🏴 WAVING BLACK FLAG
󠁧 TAG LATIN SMALL LETTER G
󠁢 TAG LATIN SMALL LETTER B
󠁥 TAG LATIN SMALL LETTER E
󠁮 TAG LATIN SMALL LETTER N
󠁧 TAG LATIN SMALL LETTER G
󠁿 CANCEL TAG
󠁧 TAG LATIN SMALL LETTER G
󠁢 TAG LATIN SMALL LETTER B
󠁥 TAG LATIN SMALL LETTER E
󠁮 TAG LATIN SMALL LETTER N
󠁧 TAG LATIN SMALL LETTER G
󠁿 CANCEL TAG
```

to 

```
🏴 WAVING BLACK FLAG
󠁧 TAG LATIN SMALL LETTER G
󠁢 TAG LATIN SMALL LETTER B
󠁥 TAG LATIN SMALL LETTER E
󠁮 TAG LATIN SMALL LETTER N
󠁧 TAG LATIN SMALL LETTER G
󠁿 CANCEL TAG
󠁧```
