### PR TITLE
wtf.fetch return scalar response for scalar input vs array response for array input

### DIFF
--- a/src/_fetch/index.js
+++ b/src/_fetch/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import unfetch from 'isomorphic-unfetch'
 import parseUrl from './parseUrl.js'
 import makeUrl from './makeUrl.js'
@@ -54,6 +53,9 @@ const fetch = function (title, options, callback) {
   if (typeof options === 'string') {
     options = { lang: options }
   }
+  if (typeof title.href === 'string') {
+    title = title.href
+  }
   options = { ...defaults, ...options }
   options.title = title
 
@@ -64,25 +66,22 @@ const fetch = function (title, options, callback) {
   const url = makeUrl(options)
   const headers = makeHeaders(options)
 
-  return unfetch(url, headers)
+  const promise = unfetch(url, headers)
     .then((res) => res.json())
     .then((res) => {
       if (!res) {
         throw new Error(`No JSON Data Found For ${url}`)
       }
-      let data = getResult(res, options)
-      data = parseDoc(data, title)
-      if (callback) {
+      const result = getResult(res, options)
+      const data = parseDoc(result, title)
+      if (typeof callback === 'function') {
         callback(null, data)
       }
       return data
     })
-    .catch((e) => {
-      console.error(e)
-      if (callback) {
-        callback(e, null)
-      }
-      return null
-    })
+
+  return typeof callback === 'function'
+    ? promise.catch((e) => callback(e, null))
+    : promise
 }
 export default fetch

--- a/src/_fetch/parseDoc.js
+++ b/src/_fetch/parseDoc.js
@@ -6,28 +6,13 @@ import { isArray } from '../_lib/helpers.js'
  * @private
  * @param {Array} res
  * @param {string | number | Array<number> | Array<string>} title
- * @returns {null| Document | Document[]} null if there are no results or Document if there is one responses and Document array if there are multiple responses
+ * @returns {null | Document | Document[]} `Document | null` if `title` is scalar, `or Document[]` if `title` is an array
  */
 const parseDoc = function (res, title) {
-  res = res || []
-  // filter out undefined
-  res = res.filter((o) => o)
+  const results = (res ?? [])
+    .filter((o) => o != null)
+    .map(o => new Document(o.wiki, o.meta))
 
-  // put all the responses into Document formats
-  let docs = res.map((o) => {
-    return new Document(o.wiki, o.meta)
-  })
-
-  // if the list is empty than there are no results
-  if (docs.length === 0) {
-    return null
-  }
-
-  // if there is only one response then we can get it out of the array
-  if (!isArray(title) && docs.length === 1) {
-    return docs[0]
-  }
-
-  return docs
+  return isArray(title) ? results : results[0] ?? null
 }
 export default parseDoc

--- a/tests/fetch/fetch.test.js
+++ b/tests/fetch/fetch.test.js
@@ -22,6 +22,31 @@ test('fetch-as-promise', (t) => {
   })
 })
 
+test('promise rejects on error if no callback', async (t) => {
+  let err
+
+  try {
+    await wtf.fetch('https://example.com', 'en')
+  } catch (e) {
+    err = e
+  }
+
+  // attempting to parse response will generate a SyntaxError due to not being JSON
+  t.equal(err.name, 'SyntaxError')
+
+  t.end()
+})
+
+test("if callback supplied, error scenario calls errback and doesn't reject promise", async (t) => {
+  await wtf.fetch('https://example.com', 'en', (err, data) => {
+    t.equal(data, null)
+    // attempting to parse response will generate a SyntaxError due to not being JSON
+    t.equal(err.name, 'SyntaxError')
+  })
+
+  t.end()
+})
+
 test('fetch-as-callback', (t) => {
   t.plan(1)
   wtf.fetch('Tony Danza', 'en', function (err, doc) {
@@ -81,7 +106,7 @@ test('ambiguous-pageids', async function (t) {
   t.equal(doc.title(), 'Arab world', 'input as pageid')
 
   doc = await wtf.fetch('1984', 'en')
-  t.equal(doc.title(), '1984', 'input as text')
+  t.equal(doc.title(), '1984 (year)', 'input as text')
 
   let docs = await wtf.fetch([2983, 7493], 'en')
   t.equal(docs.length, 2, 'got two pageid results')

--- a/tests/unit/parseDoc.test.js
+++ b/tests/unit/parseDoc.test.js
@@ -21,15 +21,15 @@ test('should filter out all the undefined values', (t) => {
   t.end()
 })
 
-test('should return null if there are no document', (t) => {
+test('should return empty if there are no documents', (t) => {
   const result = parseDoc([], [])
-  t.equal(result, null)
+  t.deepEqual(result, [])
   t.end()
 })
 
-test('should return null if there are no document', (t) => {
+test('should return empty if there are no documents', (t) => {
   const result = parseDoc([undefined], ['not hallo'])
-  t.equal(result, null)
+  t.deepEqual(result, [])
   t.end()
 })
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -191,22 +191,26 @@ declare class Sentence {
 
 export default wtf
 
-type fetchDefaults = {
+type FetchOptions = {
   path?: string | undefined;
   wiki?: string | undefined;
   domain?: string | undefined;
   follow_redirects?: boolean | undefined;
   lang?: string | undefined;
-  title?: string | number | Array<string> | Array<number> | undefined;
   "Api-User-Agent"?: string | undefined;
 };
 
-type fetchCallback = (error: any, response: (null | Document | Document[])) => any;
+type FetchCallback<T> = (...args: [err: Error, result: null] | [err: null, result: FetchResult<T>]) => void;
 
-declare function fetch(
-  title: string | number | Array<number> | Array<string>,
-  options?: fetchDefaults | undefined, callback?: fetchCallback
-): Promise<null | Document | Document[]>;
+declare function fetch<T extends string | number | string[] | number[] | URL>(
+  title: T,
+  options?: FetchOptions | undefined,
+  callback?: FetchCallback<T>
+): Promise<FetchResult<T>>;
+
+type FetchResult<T> = T extends unknown[]
+  ? Documents[]
+  : Document | null;
 
 declare function wtf(wiki: string, options?: object): Document
 declare namespace wtf {


### PR DESCRIPTION
Per https://github.com/spencermountain/wtf_wikipedia/issues/280#issuecomment-2868358603

```ts
await wtf.fetch('Mexico') // Document | null
await wtf.fetch(['Mexico', 'Colombia']) // Document[]
```

Note that this _does_ require at least one runtime change after all: `wtf.fetch(["some article that doesn't exist"])` now returns `[]` not `null`.

Also, previously errors were getting unconditionally swallowed (only printed with `console.error`) with no way to catch them if no callback was supplied. I've changed that behavior so now they only get caught and passed to the callback if a callback was supplied, otherwise they reject the promise.

This also adds support for passing a `URL` object instead of a string URL.