### PR TITLE
chore: use public markdown plugin repository URL

### DIFF
--- a/plugins/markdown/package.json
+++ b/plugins/markdown/package.json
@@ -16,7 +16,7 @@
   "homepage": "https://github.com/spencermountain/wtf_wikipedia/plugins/markdown#readme",
   "repository": {
     "type": "git",
-    "url": "git://github.com/spencermountain/wtf_wikipedia.git"
+    "url": "git+https://github.com/spencermountain/wtf_wikipedia.git"
   },
   "scripts": {
     "watch": "amble ./scratch.js",


### PR DESCRIPTION
## Summary
- update `wtf-plugin-markdown` repository metadata from the unauthenticated `git://` protocol to public `git+https`
- leave runtime code, dependencies, package version, homepage, peer dependency, and package contents unchanged

## Validation
- `node` metadata assertion for `plugins/markdown/package.json`
- `npm pack --dry-run --ignore-scripts --json ./plugins/markdown`
- `git diff --check`
- `npm install --ignore-scripts --no-audit --no-fund --package-lock=false` at the repo root
- `npm install --legacy-peer-deps --ignore-scripts --no-audit --no-fund --package-lock=false` in `plugins/markdown`
- `cd plugins/markdown && set -o pipefail && npm test` (82 assertions)
- `cd plugins/markdown && npm run build`

Note: installing only inside `plugins/markdown` leaves the root `wtf_wikipedia` build without its root dependency `isomorphic-unfetch`, so I installed root dependencies before the final test run.